### PR TITLE
initialize some variables

### DIFF
--- a/plugin/cropAndResizePlugin/cropAndResizePlugin.cpp
+++ b/plugin/cropAndResizePlugin/cropAndResizePlugin.cpp
@@ -277,7 +277,7 @@ IPluginV2Ext* CropAndResizePluginCreator::createPlugin(const char* name, const P
 {
     const PluginField* fields = fc->fields;
     int nbFields = fc->nbFields;
-    int crop_width, crop_height;
+    int crop_width = 0, crop_height = 0;
 
     for (int i = 0; i < nbFields; ++i)
     {

--- a/plugin/proposalPlugin/proposalPlugin.cpp
+++ b/plugin/proposalPlugin/proposalPlugin.cpp
@@ -358,8 +358,8 @@ IPluginV2Ext* ProposalPluginCreator::createPlugin(const char* name, const Plugin
 {
     const PluginField* fields = fc->fields;
     int nbFields = fc->nbFields;
-    int input_height, input_width, rpn_stride, pre_nms_top_n, post_nms_top_n;
-    float roi_min_size, nms_iou_threshold;
+    int input_height = 0, input_width = 0, rpn_stride = 0, pre_nms_top_n = 0, post_nms_top_n = 0;
+    float roi_min_size = 0.0f, nms_iou_threshold = 0.0f;
     std::vector<float> anchor_sizes;
     std::vector<float> anchor_ratios;
 
@@ -371,43 +371,36 @@ IPluginV2Ext* ProposalPluginCreator::createPlugin(const char* name, const Plugin
         {
             ASSERT(fields[i].type == PluginFieldType::kINT32);
             input_height = *(static_cast<const int*>(fields[i].data));
-            ASSERT(input_height > 0);
         }
         else if (!strcmp(attr_name, "input_width"))
         {
             ASSERT(fields[i].type == PluginFieldType::kINT32);
             input_width = *(static_cast<const int*>(fields[i].data));
-            ASSERT(input_width > 0);
         }
         else if (!strcmp(attr_name, "rpn_stride"))
         {
             ASSERT(fields[i].type == PluginFieldType::kINT32);
             rpn_stride = *(static_cast<const int*>(fields[i].data));
-            ASSERT(rpn_stride > 0);
         }
         else if (!strcmp(attr_name, "roi_min_size"))
         {
             ASSERT(fields[i].type == PluginFieldType::kFLOAT32);
             roi_min_size = *(static_cast<const float*>(fields[i].data));
-            ASSERT(roi_min_size >= 0.0f);
         }
         else if (!strcmp(attr_name, "nms_iou_threshold"))
         {
             ASSERT(fields[i].type == PluginFieldType::kFLOAT32);
             nms_iou_threshold = *(static_cast<const float*>(fields[i].data));
-            ASSERT(nms_iou_threshold > 0.0f);
         }
         else if (!strcmp(attr_name, "pre_nms_top_n"))
         {
             ASSERT(fields[i].type == PluginFieldType::kINT32);
             pre_nms_top_n = *(static_cast<const int*>(fields[i].data));
-            ASSERT(pre_nms_top_n > 0);
         }
         else if (!strcmp(attr_name, "post_nms_top_n"))
         {
             ASSERT(fields[i].type == PluginFieldType::kINT32);
             post_nms_top_n = *(static_cast<const int*>(fields[i].data));
-            ASSERT(post_nms_top_n > 0);
         }
         else if (!strcmp(attr_name, "anchor_sizes"))
         {
@@ -435,6 +428,9 @@ IPluginV2Ext* ProposalPluginCreator::createPlugin(const char* name, const Plugin
             }
         }
     }
+
+    ASSERT(input_height > 0 && input_width > 0 && rpn_stride > 0 && pre_nms_top_n > 0 && post_nms_top_n 
+        && roi_min_size >= 0.0f && nms_iou_threshold > 0.0f);
 
     IPluginV2Ext* plugin = new ProposalPlugin(name, input_height, input_width, RPN_STD_SCALING, rpn_stride,
         roi_min_size, nms_iou_threshold, pre_nms_top_n, post_nms_top_n, &anchor_sizes[0], anchor_sizes.size(),


### PR DESCRIPTION
These just came from clang-tidy. The issue is if these fields aren't set in the `PluginField` array (which I guess is not an intended use), they can sneak into the Plugin as uninitialzed data, and undefined behavior may result.

Even if it's always the intended use that these fields be set, a consequence of undefined behavior is severe. This is a cheap and easy thing to check for, and parsers should be as helpful as possible.