### PR TITLE
[samples] Remove NVPARTNER from building "proprietary samples"

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -18,6 +18,6 @@ add_custom_target(samples)
 
 add_subdirectory(opensource)
 
-if(NVINTERNAL OR NVPARTNER)
+if(NVINTERNAL)
     add_subdirectory(proprietary)
 endif()


### PR DESCRIPTION
Builds will break for partners who don't get the proprietary sample
source out of the box, I think it's better if we ask people who do to change
this line vs. the builds being broken for everyone else.

Signed-off-by: Naren Dasan <naren@narendasan.com>
Signed-off-by: Naren Dasan <narens@nvidia.com>