### PR TITLE
add web link to NVIDIA logo in BERT demo

### DIFF
--- a/demo/BERT/python/BERT_TRT.ipynb
+++ b/demo/BERT/python/BERT_TRT.ipynb
@@ -26,7 +26,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"img/nvidia_logo.png\" style=\"width: 90px; float: right;\">\n",
+    "<img src=\"https://upload.wikimedia.org/wikipedia/en/6/6d/Nvidia_image_logo.svg\" style=\"width: 90px; float: right;\">\n",
     "\n",
     "# QA Inference on BERT using TensorRT"
    ]


### PR DESCRIPTION
add web link to NVIDIA logo since local image doesn't exist. Alternatively, we can add `img/nvidia_logo.png` to the repo.