### PR TITLE
TensorRT installation minor bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ NOTE: Along with the TensorRT OSS components, the following source packages will
 	Download and extract the *TensorRT 6.0.1.5 GA for Ubuntu 18.04 and CUDA 10.1 tar package*
 	```bash
 	cd ~/Downloads
-	# Download TensorRT-6.0.1.5.Ubuntu-18.04.2.x86_64-gnu.cuda-10.1.cudnn7.6.tar.gz
-	tar -xvzf TensorRT-6.0.1.5.Ubuntu-18.04.2.x86_64-gnu.cuda-10.1.cudnn7.6.tar.gz
+	# Download TensorRT-6.0.1.5.Ubuntu-18.04.x86_64-gnu.cuda-10.1.cudnn7.6.tar.gz
+	tar -xvzf TensorRT-6.0.1.5.Ubuntu-18.04.x86_64-gnu.cuda-10.1.cudnn7.6.tar.gz
 	export TRT_RELEASE=`pwd`/TensorRT-6.0.1.5
 	```
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ NOTE: Along with the TensorRT OSS components, the following source packages will
 	# Download TensorRT-6.0.1.5.Ubuntu-18.04.x86_64-gnu.cuda-10.1.cudnn7.6.tar.gz
 	tar -xvzf TensorRT-6.0.1.5.Ubuntu-18.04.x86_64-gnu.cuda-10.1.cudnn7.6.tar.gz
 	export TRT_RELEASE=`pwd`/TensorRT-6.0.1.5
+	export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TRT_RELEASE/lib
 	```
 
 	**Example: CentOS/RedHat 7 with cuda-9.0**
@@ -87,6 +88,7 @@ NOTE: Along with the TensorRT OSS components, the following source packages will
 	# Download TensorRT-6.0.1.5.Red-Hat.x86_64-gnu.cuda-9.0.cudnn7.6.tar.gz
 	tar -xvzf TensorRT-6.0.1.5.Red-Hat.x86_64-gnu.cuda-9.0.cudnn7.6.tar.gz
 	export TRT_RELEASE=~/Downloads/TensorRT-6.0.1.5
+	export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TRT_RELEASE/lib
 	```
 
 ## Setting Up The Build Environment

--- a/README.md
+++ b/README.md
@@ -193,8 +193,12 @@ NOTE: Along with the TensorRT OSS components, the following source packages will
 * Verify the TensorRT samples have been installed correctly.
 
 	```bash
+<<<<<<< HEAD
 	cd $TRT_LIB_DIR/../bin/
 	./sample_googlenet
+=======
+	$TRT_LIB_DIR/../bin/sample_googlenet
+>>>>>>> set runtime path of sample executable to shared library correctly.
 	```
 
 	If the sample was installed correctly, the following information will be printed out in the terminal.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ NOTE: Along with the TensorRT OSS components, the following source packages will
 	cd ~/Downloads
 	# Download TensorRT-6.0.1.5.Red-Hat.x86_64-gnu.cuda-9.0.cudnn7.6.tar.gz
 	tar -xvzf TensorRT-6.0.1.5.Red-Hat.x86_64-gnu.cuda-9.0.cudnn7.6.tar.gz
-	export TRT_RELEASE=~/Downloads/TensorRT-6.0.1.5
+	export TRT_RELEASE=`pwd`/TensorRT-6.0.1.5
 	export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TRT_RELEASE/lib
 	```
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ NOTE: Along with the TensorRT OSS components, the following source packages will
 * Verify the TensorRT samples have been installed correctly.
 
 	```bash
-	$TRT_LIB_DIR/../bin/sample_googlenet
+	cd $TRT_LIB_DIR/../bin/
+	./sample_googlenet
 	```
 
 	If the sample was installed correctly, the following information will be printed out in the terminal.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,23 @@ NOTE: Along with the TensorRT OSS components, the following source packages will
 	```bash
 	sudo make install
 	```
+* Verify the TensorRT samples have been installed correctly.
+
+	```bash
+	$TRT_LIB_DIR/../bin/sample_googlenet
+	```
+
+	If the sample was installed correctly, the following information will be printed out in the terminal.
+
+	```bash
+	[08/23/2019-22:08:57] [I] Building and running a GPU inference engine for GoogleNet
+	[08/23/2019-22:08:59] [I] [TRT] Some tactics do not have sufficient workspace memory to run. Increasing workspace size may increase performance, please check verbose output.
+	[08/23/2019-22:09:05] [I] [TRT] Detected 1 inputs and 1 output network tensors.
+	[08/23/2019-22:09:05] [I] Ran /tensorrt/bin/sample_googlenet with: 
+	[08/23/2019-22:09:05] [I] Input(s): data 
+	[08/23/2019-22:09:05] [I] Output(s): prob 
+	&&&& PASSED TensorRT.sample_googlenet # /tensorrt/bin/sample_googlenet
+	```
 
 ## Useful Resources
 

--- a/README.md
+++ b/README.md
@@ -193,12 +193,8 @@ NOTE: Along with the TensorRT OSS components, the following source packages will
 * Verify the TensorRT samples have been installed correctly.
 
 	```bash
-<<<<<<< HEAD
 	cd $TRT_LIB_DIR/../bin/
 	./sample_googlenet
-=======
-	$TRT_LIB_DIR/../bin/sample_googlenet
->>>>>>> set runtime path of sample executable to shared library correctly.
 	```
 
 	If the sample was installed correctly, the following information will be printed out in the terminal.

--- a/docker/centos-7.Dockerfile
+++ b/docker/centos-7.Dockerfile
@@ -43,7 +43,11 @@ RUN cd /tmp &&\
 ENV TRT_RELEASE /tensorrt
 ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
+<<<<<<< HEAD
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
+=======
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
+>>>>>>> use LD_LIBRARY_PATH
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/centos-7.Dockerfile
+++ b/docker/centos-7.Dockerfile
@@ -41,8 +41,9 @@ RUN cd /tmp &&\
 
 # Set environment and working directory
 ENV TRT_RELEASE /tensorrt
+ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
-ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/centos-7.Dockerfile
+++ b/docker/centos-7.Dockerfile
@@ -42,6 +42,7 @@ RUN cd /tmp &&\
 # Set environment and working directory
 ENV TRT_RELEASE /tensorrt
 ENV TRT_SOURCE /workspace/TensorRT
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/centos-7.Dockerfile
+++ b/docker/centos-7.Dockerfile
@@ -43,11 +43,7 @@ RUN cd /tmp &&\
 ENV TRT_RELEASE /tensorrt
 ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
-<<<<<<< HEAD
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
-=======
-ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
->>>>>>> use LD_LIBRARY_PATH
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-16.04.Dockerfile
+++ b/docker/ubuntu-16.04.Dockerfile
@@ -41,6 +41,7 @@ RUN cd /tmp &&\
 # Set environment and working directory
 ENV TRT_RELEASE /tensorrt
 ENV TRT_SOURCE /workspace/TensorRT
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-16.04.Dockerfile
+++ b/docker/ubuntu-16.04.Dockerfile
@@ -42,7 +42,11 @@ RUN cd /tmp &&\
 ENV TRT_RELEASE /tensorrt
 ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
+<<<<<<< HEAD
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
+=======
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
+>>>>>>> use LD_LIBRARY_PATH
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-16.04.Dockerfile
+++ b/docker/ubuntu-16.04.Dockerfile
@@ -40,8 +40,9 @@ RUN cd /tmp &&\
 
 # Set environment and working directory
 ENV TRT_RELEASE /tensorrt
+ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
-ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-16.04.Dockerfile
+++ b/docker/ubuntu-16.04.Dockerfile
@@ -42,11 +42,7 @@ RUN cd /tmp &&\
 ENV TRT_RELEASE /tensorrt
 ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
-<<<<<<< HEAD
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
-=======
-ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
->>>>>>> use LD_LIBRARY_PATH
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-18.04-cross-aarch64.Dockerfile
+++ b/docker/ubuntu-18.04-cross-aarch64.Dockerfile
@@ -86,7 +86,11 @@ RUN cd /pdk_files/tensorrt \
 ENV TRT_RELEASE /tensorrt
 ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
+<<<<<<< HEAD
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
+=======
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
+>>>>>>> use LD_LIBRARY_PATH
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-18.04-cross-aarch64.Dockerfile
+++ b/docker/ubuntu-18.04-cross-aarch64.Dockerfile
@@ -86,11 +86,7 @@ RUN cd /pdk_files/tensorrt \
 ENV TRT_RELEASE /tensorrt
 ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
-<<<<<<< HEAD
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
-=======
-ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
->>>>>>> use LD_LIBRARY_PATH
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-18.04-cross-aarch64.Dockerfile
+++ b/docker/ubuntu-18.04-cross-aarch64.Dockerfile
@@ -83,7 +83,7 @@ RUN cd /pdk_files/tensorrt \
        ; done
 
 # Set environment and working directory
-ENV TRT_RELEASE /tensorrt
+ENV TRT_RELEASE /pdk_files/tensorrt
 ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR

--- a/docker/ubuntu-18.04-cross-aarch64.Dockerfile
+++ b/docker/ubuntu-18.04-cross-aarch64.Dockerfile
@@ -83,9 +83,10 @@ RUN cd /pdk_files/tensorrt \
        ; done
 
 # Set environment and working directory
-ENV TRT_RELEASE /pdk_files/tensorrt
+ENV TRT_RELEASE /tensorrt
+ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
-ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-18.04-cross-aarch64.Dockerfile
+++ b/docker/ubuntu-18.04-cross-aarch64.Dockerfile
@@ -85,6 +85,7 @@ RUN cd /pdk_files/tensorrt \
 # Set environment and working directory
 ENV TRT_RELEASE /pdk_files/tensorrt
 ENV TRT_SOURCE /workspace/TensorRT
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-18.04.Dockerfile
+++ b/docker/ubuntu-18.04.Dockerfile
@@ -41,6 +41,7 @@ RUN cd /tmp &&\
 # Set environment and working directory
 ENV TRT_RELEASE /tensorrt
 ENV TRT_SOURCE /workspace/TensorRT
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-18.04.Dockerfile
+++ b/docker/ubuntu-18.04.Dockerfile
@@ -42,7 +42,11 @@ RUN cd /tmp &&\
 ENV TRT_RELEASE /tensorrt
 ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
+<<<<<<< HEAD
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
+=======
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
+>>>>>>> use LD_LIBRARY_PATH
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-18.04.Dockerfile
+++ b/docker/ubuntu-18.04.Dockerfile
@@ -40,8 +40,9 @@ RUN cd /tmp &&\
 
 # Set environment and working directory
 ENV TRT_RELEASE /tensorrt
+ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
-ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/docker/ubuntu-18.04.Dockerfile
+++ b/docker/ubuntu-18.04.Dockerfile
@@ -42,11 +42,7 @@ RUN cd /tmp &&\
 ENV TRT_RELEASE /tensorrt
 ENV TRT_LIB_DIR $TRT_RELEASE/lib
 ENV TRT_SOURCE /workspace/TensorRT
-<<<<<<< HEAD
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_LIB_DIR
-=======
-ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$TRT_RELEASE/lib
->>>>>>> use LD_LIBRARY_PATH
 WORKDIR /workspace
 
 RUN ["/bin/bash"]

--- a/samples/CMakeSamplesTemplate.txt
+++ b/samples/CMakeSamplesTemplate.txt
@@ -29,6 +29,9 @@ get_filename_component(SAMPLE_DIR_NAME ${TARGET_DIR} NAME)
 
 set(CUDA_INSTALL_DIR /usr/local/cuda)
 
+# Make sure the shared library path is correct for samples
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 # SAMPLES_COMMON_SOURCES
 set(SAMPLES_COMMON_SOURCES
     ${SAMPLES_DIR}/common/logger.cpp

--- a/samples/CMakeSamplesTemplate.txt
+++ b/samples/CMakeSamplesTemplate.txt
@@ -29,9 +29,6 @@ get_filename_component(SAMPLE_DIR_NAME ${TARGET_DIR} NAME)
 
 set(CUDA_INSTALL_DIR /usr/local/cuda)
 
-# Make sure the shared library path is correct for samples
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 # SAMPLES_COMMON_SOURCES
 set(SAMPLES_COMMON_SOURCES
     ${SAMPLES_DIR}/common/logger.cpp


### PR DESCRIPTION
When running TensorRT official examples after installation in the Docker, error message `error while loading shared libraries: ...` occurred.

This patch fixed the problem by:
* set runtime path of sample executable to shared library correctly in CMakeLists.txt.

Additional minor changes
* fix TensorRT tar filename.
* Add verification for samples after installation.