### PR TITLE
Comment out instructions so they don't show up in issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ## Description
 
-A clear and concise description of the bug or issue.
+<!-- A clear and concise description of the bug or issue. -->
 
 
 ## Environment
@@ -28,16 +28,17 @@ A clear and concise description of the bug or issue.
 
 ## Relevant Files
 
-Please include links to any models, data, files, or scripts necessary to reproduce your issue. (Github repo, Google Drive, Dropbox, etc.)
+<!-- Please include links to any models, data, files, or scripts necessary to reproduce your issue. (Github repo, Google Drive, Dropbox, etc.) -->
 
 
 ## Steps To Reproduce
 
-Craft a minimal bug report following this guide - https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
+<!-- 
+  Craft a minimal bug report following this guide - https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
 
-Please include:
-* Exact steps/commands to build your repro
-* Exact steps/commands to run your repro
-* Full traceback of errors encountered
-
+  Please include:
+  * Exact steps/commands to build your repro
+  * Exact steps/commands to run your repro
+  * Full traceback of errors encountered 
+-->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,10 +19,10 @@ assignees: ''
 **Nvidia Driver Version**: 
 **CUDA Version**: 
 **CUDNN Version**: 
+**Operating System + Version**: 
 **Python Version (if applicable)**: 
 **TensorFlow Version (if applicable)**: 
 **PyTorch Version (if applicable)**: 
-**Operating System + Version**: 
 **Baremetal or Container (if container which image + tag)**: 
 
 


### PR DESCRIPTION
Several issues have been filed where they don't actually fill in some of the fields. I want to make that more obvious at first glance by not having the instructions visible in the rendered issue.

Test issue: https://github.com/rmccorm4/TensorRT/issues/1

