### PR TITLE
Adding CUDA_VERSION check for compiling BERT plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,14 +188,21 @@ else()
 
     include_directories(
         ${CUDA_INCLUDE_DIRS}
+        ${CUDNN_ROOT_DIR}/include
     )
     find_library(CUDNN_LIB cudnn HINTS
         ${CUDA_TOOLKIT_ROOT_DIR} ${CUDNN_ROOT_DIR} PATH_SUFFIXES lib64 lib)
     find_library(CUBLAS_LIB cublas HINTS
         ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
-
-    find_library(CUBLASLT_LIB cublasLt HINTS
-        ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
+    # CUBLASLT libraries are only available in CUDA versions > 10. Check for CUDA version here and
+    # remove dependency on the libarary and unset BERT_GENCODES.
+    if (CUDA_VERSION VERSION_LESS_EQUAL 10.0)
+        message(WARNING "Detected CUDA version is <= 10.0! Removing BERT plugins from compilation list.")
+        unset(BERT_GENCODES)
+    else()
+        find_library(CUBLASLT_LIB cublasLt HINTS
+            ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
+    endif()
     if(BUILD_PARSERS)
         configure_protobuf(${PROTOBUF_VERSION})
     endif()


### PR DESCRIPTION
* BERT plugins require `CUBLASLT` to compile, but this library is only available post CUDA 10.0. Add check to remove these sources if detected CUDA version is <= 10

* Add `${CUDNN_ROOT_DIR}/include` to base set of `include_directories` to streamline local builds.