### PR TITLE
fix FlattenConcat plugin seg fault when loaded from serialized engine

### DIFF
--- a/plugin/flattenConcat/flattenConcat.cpp
+++ b/plugin/flattenConcat/flattenConcat.cpp
@@ -89,6 +89,9 @@ FlattenConcat::FlattenConcat(const void* data, size_t length)
     std::for_each(mCopySize, mCopySize + mNumInputs, [&](size_t& inp) { inp = read<size_t>(d); });
 
     ASSERT(d == a + length);
+
+    // Create cublas context after deserialization
+    LOG_ERROR(cublasCreate(&mCublas));
 }
 
 FlattenConcat::~FlattenConcat()


### PR DESCRIPTION
Fix `FlattenConcat_TRT` plugin segmentation fault during `ICudaEngine` `destroy()`.

When an `ICudaEngine` object with this plugin is serialized to disk and then deserialized for repeated use, `mCublas` handle is not initialized and triggers a bug in `FlattenConcat::terminate()` function.

Signed-off-by: jingyu.qian <jingyu.qian@inceptioglobal.ai>