### PR TITLE
add resize for caffe

### DIFF
--- a/parsers/caffe/CaffeParserSources.txt
+++ b/parsers/caffe/CaffeParserSources.txt
@@ -40,6 +40,7 @@ set(CAFFE_PARSER_SRCS
     caffeParser/opParsers/parseSigmoid.cpp
     caffeParser/opParsers/parseSoftMax.cpp
     caffeParser/opParsers/parseTanH.cpp
+    caffeParser/opParsers/parseResize.cpp
     caffeWeightFactory/caffeWeightFactory.cpp
     caffeParser/caffeParser.cpp
     NvCaffeParser.cpp

--- a/parsers/caffe/caffeParser/opParsers/opParsers.h
+++ b/parsers/caffe/caffeParser/opParsers/opParsers.h
@@ -70,6 +70,7 @@ nvinfer1::ILayer* parseScale(nvinfer1::INetworkDefinition& network, const trtcaf
 nvinfer1::ILayer* parseSigmoid(nvinfer1::INetworkDefinition& network, const trtcaffe::LayerParameter& msg, CaffeWeightFactory& /*weightFactory*/, BlobNameToTensor& tensors);
 nvinfer1::ILayer* parseSoftMax(nvinfer1::INetworkDefinition& network, const trtcaffe::LayerParameter& msg, CaffeWeightFactory& /*weightFactory*/, BlobNameToTensor& tensors);
 nvinfer1::ILayer* parseTanH(nvinfer1::INetworkDefinition& network, const trtcaffe::LayerParameter& msg, CaffeWeightFactory& /*weightFactory*/, BlobNameToTensor& tensors);
+nvinfer1::ILayer* parseResize(nvinfer1::INetworkDefinition& network, const trtcaffe::LayerParameter& msg, CaffeWeightFactory& /*weightFactory*/, BlobNameToTensor& tensors);
 
 static std::unordered_map<std::string, LayerParseFn> gParseTable 
 {
@@ -96,7 +97,8 @@ static std::unordered_map<std::string, LayerParseFn> gParseTable
     {"BNLL", parseBNLL},
     {"Clip", parseClip},
     {"AbsVal", parseAbsVal},
-    {"PReLU", parsePReLU}
+    {"PReLU", parsePReLU},
+    {"Resize", parseResize}
 };
 } // namespace nvcaffeparser1
 #endif //TRT_CAFFE_PARSER_OP_PARSERS_H

--- a/parsers/caffe/caffeParser/opParsers/parseResize.cpp
+++ b/parsers/caffe/caffeParser/opParsers/parseResize.cpp
@@ -1,0 +1,52 @@
+/* Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "opParsers.h"
+
+using namespace nvinfer1;
+
+namespace nvcaffeparser1
+{
+ILayer* parseResize(INetworkDefinition& network, const trtcaffe::LayerParameter& msg, CaffeWeightFactory& /* weightFactory */, BlobNameToTensor& tensors)
+{
+    if (!checkBlobs(msg, 1, 1))
+    {
+        return nullptr;
+    }
+    if (getInferLibVersion() <= 5000) {
+      RETURN_AND_LOG_ERROR(nullptr, "IResizeLayer can be supported by TensorRT6 or Newer version");
+      
+    }
+
+    const trtcaffe::ResizeParameter& p = msg.resize_param();
+
+    auto mode = p.interp_mode(0);
+    nvinfer1::ResizeMode resizeMode;
+    if (mode == trtcaffe::ResizeParameter_Interp_mode_NEAREST) {
+      resizeMode = nvinfer1::ResizeMode::kNEAREST;
+    } else if (mode == trtcaffe::ResizeParameter_Interp_mode_LINEAR) {
+      resizeMode = nvinfer1::ResizeMode::kLINEAR;
+    } else {
+      RETURN_AND_LOG_ERROR(nullptr, "This version of TensorRT only supports nearest or linear mode!");
+    }
+    float scales[] = {1, (float)(p.height_scale()), (float)(p.width_scale())};
+
+    nvinfer1::IResizeLayer* layer = network.addResize(*tensors[msg.bottom(0)]);
+    layer->setResizeMode(resizeMode);
+    layer->setScales(scales, 3);
+    return layer;
+}
+} //namespace nvcaffeparser1
+

--- a/parsers/caffe/proto/trtcaffe.proto
+++ b/parsers/caffe/proto/trtcaffe.proto
@@ -512,6 +512,7 @@ message LayerParameter {
   // please note that the serialization number for ClipParameter differs from
   // Caffe master, since 148 was already used for a custom field
   optional ClipParameter clip_param = 8787;
+  optional ResizeParameter resize_param = 8788;
 }
 
 // Message that stores parameters used to apply transformation


### PR DESCRIPTION
Add Resize layer for caffe.

this feature is indeed necessary since Feature pyramid architecture is very common in object detection.