### PR TITLE
ONNX-MNIST-Sample

### DIFF
--- a/data/mnist/README.md
+++ b/data/mnist/README.md
@@ -1,0 +1,17 @@
+# Setting Up MNIST Samples
+
+## Downloading PGMs for Inference
+
+To download PGMs from the MNIST dataset, you can run the included `download_pgms.py` script:
+```bash
+python3 download_pgms.py
+```
+
+## Models
+
+To download the MNIST model from the [ONNX Model Zoo](https://github.com/onnx/models/tree/master/vision/classification/mnist), use:
+```bash
+chmod +x download_model.sh
+./download_model.sh 
+```
+

--- a/data/mnist/download_model.sh
+++ b/data/mnist/download_model.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Downloads the ONNX MNIST Model from the model zoo.
+wget https://onnxzoo.blob.core.windows.net/models/opset_8/mnist/mnist.tar.gz
+tar -xzvf mnist.tar.gz
+# rename model to mnist.onnx
+mv mnist/model.onnx mnist.onnx
+# Delete MNIST data set and archive
+rm -r mnist
+rm -r mnist.tar*
+

--- a/data/mnist/download_pgms.py
+++ b/data/mnist/download_pgms.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+from PIL import Image
+import urllib.request
+import numpy as np
+import argparse
+import gzip
+import os
+
+
+# Returns a numpy buffer of shape (num_images, 28, 28)
+def load_mnist_data(buffer):
+    raw_buf = np.fromstring(buffer, dtype=np.uint8)
+    # Make sure the magic number is what we expect
+    assert raw_buf[0:4].view(">i4")[0] == 2051
+    num_images = raw_buf[4:8].view(">i4")[0]
+    image_h = raw_buf[8:12].view(">i4")[0]
+    image_w = raw_buf[12:16].view(">i4")[0]
+    # Colors in the dataset are inverted vs. what the samples expect.
+    return np.ascontiguousarray(255 - raw_buf[16:].reshape(num_images, image_h, image_w))
+
+# Returns a list of length num_images
+def load_mnist_labels(buffer):
+    raw_buf = np.fromstring(buffer, dtype=np.uint8)
+    # Make sure the magic number is what we expect
+    assert raw_buf[0:4].view(">i4")[0] == 2049
+    num_labels = raw_buf[4:8].view(">i4")[0]
+    return list(raw_buf[8:].astype(np.int32).reshape(num_labels))
+
+def main():
+    parser = argparse.ArgumentParser(description="Extracts 10 PGM files from the MNIST dataset", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-o", "--output", help="Path to the output directory.", default=os.getcwd())
+
+    args, _ = parser.parse_known_args()
+
+    with urllib.request.urlopen("http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz") as res:
+        data = load_mnist_data(gzip.decompress(res.read()))
+
+    with urllib.request.urlopen("http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz") as res:
+        labels = load_mnist_labels(gzip.decompress(res.read()))
+
+    output_dir = args.output
+
+    # Find one image for each digit.
+    for i in range(10):
+        index = labels.index(i)
+        image = Image.fromarray(data[index], mode="L")
+        path = os.path.join(output_dir, "{:}.pgm".format(i))
+        image.save(path)
+
+if __name__ == '__main__':
+    main()
+

--- a/samples/opensource/sampleOnnxMNIST/README.md
+++ b/samples/opensource/sampleOnnxMNIST/README.md
@@ -96,20 +96,29 @@ The Shuffle layer implements a reshape and transpose operator for tensors.
 
 ## Running the sample
 
-1.  Compile this sample by running `make` in the `<TensorRT root directory>/samples/sampleOnnxMNIST` directory. The binary named `sample_onnx_mnist` will be created in the `<TensorRT root directory>/bin` directory.
+1.  Download the ONNX-Model and sample pgm files in the data directory:
+        ```
+        cd <TensorRT root directory>/data/mnist
+        python dowload_pgms.py
+	chmod +x download_model.sh
+	./download_model.sh
+        ```
+
+2.  Compile this sample by running `cmake CMakeLists.txt` followed by `make` in the `<TensorRT root directory>/samples/opensource/sampleOnnxMNIST` directory. The binary named `sample_onnx_mnist` will be created in the `<TensorRT root directory>/bin` directory.
 	```
-	cd <TensorRT root directory>/samples/sampleOnnxMNIST
+	cd <TensorRT root directory>/samples/opensource/sampleOnnxMNIST
+	cmake CMakeLists.txt
 	make
 	```
 
 	Where `<TensorRT root directory>` is where you installed TensorRT.
 
-2.  Run the sample to build and run the MNIST engine from the ONNX model.
+3. Run the sample to build and run the MNIST engine from the ONNX model.
 	```
 	./sample_onnx_mnist [-h or --help] [-d or --datadir=<path to data directory>] [--useDLACore=<int>] [--int8 or --fp16]
 	```
 
-3.  Verify that the sample ran successfully. If the sample runs successfully you should see output similar to the following:
+4.  Verify that the sample ran successfully. If the sample runs successfully you should see output similar to the following:
 	```
 	&&&& RUNNING TensorRT.sample_onnx_mnist # ./sample_onnx_mnist
 	----------------------------------------------------------------
@@ -208,6 +217,8 @@ For terms and conditions for use, reproduction, and distribution, see the [Tenso
 March 2019
 This `README.md` file was recreated, updated and reviewed.
 
+February 2020
+The `README.md` was updated for using CMakeLists.txt files.
 
 # Known issues
 


### PR DESCRIPTION
This PR adds a data directory which is needed to follow the ONNX-MNIST-Sample.
The pgm-files can be downloaded by the original `download_pgms.py` script and the ONNX-model can be dowloaded using `./download_model.sh`.
Furthermore, the ONNX-Sample-README is updated accordingly.