### PR TITLE
trtexec core dumps when parsing mobilenet cache

### DIFF
--- a/samples/common/sampleEngines.cpp
+++ b/samples/common/sampleEngines.cpp
@@ -234,7 +234,10 @@ const void* RndInt8Calibrator::readCalibrationCache(size_t& length)
             std::istream_iterator<char>(input), std::istream_iterator<char>(), std::back_inserter(mCalibrationCache));
     }
 
-    return mCalibrationCache.size() ? mCalibrationCache.data() : nullptr;
+    // return size to the caller
+    length = mCalibrationCache.size();
+
+    return length ? mCalibrationCache.data() : nullptr;
 }
 
 void setTensorScales(const INetworkDefinition& network, float inScales = 2.0f, float outScales = 4.0f)


### PR DESCRIPTION
While running trtexec as described in issue #359 I saw the following
error:

 terminate called after throwing an instance of 'std::bad_alloc'
   what():  std::bad_alloc
 Aborted (core dumped)

The change in this PR will ensure that a valid size is being returned
to the caller in the length parameter, previously the length was not
returned