### PR TITLE
Fix a bug that causes error when batchSize > 1

### DIFF
--- a/plugin/batchTilePlugin/batchTilePlugin.cpp
+++ b/plugin/batchTilePlugin/batchTilePlugin.cpp
@@ -95,7 +95,7 @@ DataType BatchTilePlugin::getOutputDataType(int index, const nvinfer1::DataType*
 
 int BatchTilePlugin::enqueue(int batchSize, const void* const* inputs, void** outputs, void*, cudaStream_t stream)
 {
-    float* output = reinterpret_cast<float*>(outputs[0]);
+    char* output = reinterpret_cast<char*>(outputs[0]);
     // expand to batch size
     for (int i = 0; i < batchSize; i++)
     {


### PR DESCRIPTION
`output + i * mCopySize` in `cudaMemcpyAsync` will offset `i*mCopySize*sizeof(float)` bytes. This causes error sometimes if batchSize > 1.

Signed-off-by: Jeffery Zhao <zeyuz@nvidia.com>