### PR TITLE
fixing batchedNMSPlugin namespace problem

### DIFF
--- a/plugin/batchedNMSPlugin/batchedNMSPlugin.cpp
+++ b/plugin/batchedNMSPlugin/batchedNMSPlugin.cpp
@@ -187,12 +187,12 @@ IPluginV2Ext* BatchedNMSPlugin::clone() const
 
 void BatchedNMSPlugin::setPluginNamespace(const char* pluginNamespace)
 {
-    mPluginNamespace = pluginNamespace;
+    mNamespace = pluginNamespace;
 }
 
 const char* BatchedNMSPlugin::getPluginNamespace() const
 {
-    return mPluginNamespace;
+    return mNamespace.c_str();
 }
 
 nvinfer1::DataType BatchedNMSPlugin::getOutputDataType(

--- a/plugin/batchedNMSPlugin/batchedNMSPlugin.h
+++ b/plugin/batchedNMSPlugin/batchedNMSPlugin.h
@@ -88,7 +88,6 @@ private:
     int numPriors{};
     std::string mNamespace;
     bool mClipBoxes{};
-    const char* mPluginNamespace;
 };
 
 class BatchedNMSPluginCreator : public BaseCreator


### PR DESCRIPTION
issue: #448 https://github.com/NVIDIA/TensorRT/issues/448

Namespace varible used in clone() is different from setPluginNamespace() and getPluginNamespace(). Lead to corrupted memory. 