### PR TITLE
Fix a typo (in comments) in the SampleMNISTAPI Example

### DIFF
--- a/samples/opensource/sampleMNISTAPI/sampleMNISTAPI.cpp
+++ b/samples/opensource/sampleMNISTAPI/sampleMNISTAPI.cpp
@@ -201,7 +201,7 @@ bool SampleMNISTAPI::constructNetwork(SampleUniquePtr<nvinfer1::IBuilder>& build
     assert(conv2);
     conv2->setStride(DimsHW{1, 1});
 
-    // Add second max pooling layer with stride of 2x2 and kernel size of 2x3>
+    // Add second max pooling layer with stride of 2x2 and kernel size of 2x2.
     IPoolingLayer* pool2 = network->addPoolingNd(*conv2->getOutput(0), PoolingType::kMAX, Dims{2, {2, 2}, {}});
     assert(pool2);
     pool2->setStride(DimsHW{2, 2});


### PR DESCRIPTION
There was a minor typing mistake in the comments for `pool2` layer (please see file change) for SampleMNISTAPI example. 

I'm not sure if these comments are used to build any existing documentation page, but it just helps to avoid any typing mistakes (specially here, since 2x3 and 2x2 give different meaning to the code). 

This PR just updates that.

Before:  `// Add second max pooling layer with stride of 2x2 and kernel size of 2x3>`.
Now:  `// Add second max pooling layer with stride of 2x2 and kernel size of 2x2.`

Signed-off-by: krshrimali kushashwaravishrimali@gmail.com