### PR TITLE
[To Disable LayerFusion] add copyOutputToHost function for only selected outputs

### DIFF
--- a/samples/common/buffers.h
+++ b/samples/common/buffers.h
@@ -394,6 +394,24 @@ public:
     }
 
     //!
+    //! \brief Copy the selected contents of output device buffers by bidingIdx to output host buffers synchronously.
+    //!
+    void copyOutputToHost(const std::vector<int>& bindingIndices) 
+    { 
+        for (int i : bindingIndices)
+        {
+          void* dstPtr = mManagedBuffers[i]->hostBuffer.data();
+          const void* srcPtr = mManagedBuffers[i]->deviceBuffer.data();
+          const size_t byteSize = mManagedBuffers[i]->hostBuffer.nbBytes();
+          const cudaMemcpyKind memcpyType = cudaMemcpyDeviceToHost;
+          if (!mEngine->bindingIsInput(i))
+          {
+            CHECK(cudaMemcpy(dstPtr, srcPtr, byteSize, memcpyType));
+          }
+        }
+    }
+
+    //!
     //! \brief Copy the contents of input host buffers to input device buffers asynchronously.
     //!
     void copyInputToDeviceAsync(const cudaStream_t& stream = 0)
@@ -408,6 +426,24 @@ public:
     {
         memcpyBuffers(false, true, true, stream);
     }
+
+    //!
+    //! \brief Copy the selected contents of output device buffers to output host buffers asynchronously.
+    //!
+    void copyOutputToHostAsync(const std::vector<int>& bindingIndices, const cudaStream_t& stream = 0)
+    {
+        for (int i : bindingIndices)
+        {
+          void* dstPtr = mManagedBuffers[i]->hostBuffer.data();
+          const void* srcPtr = mManagedBuffers[i]->deviceBuffer.data();
+          const size_t byteSize = mManagedBuffers[i]->hostBuffer.nbBytes();
+          const cudaMemcpyKind memcpyType = cudaMemcpyDeviceToHost;
+          if (!mEngine->bindingIsInput(i))
+          {
+            CHECK(cudaMemcpy(dstPtr, srcPtr, byteSize, memcpyType, stream));
+          }
+        }
+    } 
 
     ~BufferManager() = default;
 


### PR DESCRIPTION
When there are some bugs in Layer fusion or you just want to debug, 
[https://github.com/NVIDIA/TensorRT/issues/380#issuecomment-592802132](url)
using mark_output is the only one solution to disable layer fusion. 
[https://github.com/NVIDIA/TensorRT/issues/252#issuecomment-577468499 ](url)

But if use it, the latency increases when copyOutputToHost to bring unintended outputs.  
So added two functions in buffers.h to bring the only selected outputs(by index) to Host.  


