### PR TITLE
Remove redundant mPluginNamespace in BatchedNMSPlugin

### DIFF
--- a/plugin/batchedNMSPlugin/batchedNMSPlugin.cpp
+++ b/plugin/batchedNMSPlugin/batchedNMSPlugin.cpp
@@ -187,12 +187,12 @@ IPluginV2Ext* BatchedNMSPlugin::clone() const
 
 void BatchedNMSPlugin::setPluginNamespace(const char* pluginNamespace)
 {
-    mPluginNamespace = pluginNamespace;
+    mNamespace = pluginNamespace;
 }
 
 const char* BatchedNMSPlugin::getPluginNamespace() const
 {
-    return mPluginNamespace;
+    return mNamespace;
 }
 
 nvinfer1::DataType BatchedNMSPlugin::getOutputDataType(

--- a/plugin/batchedNMSPlugin/batchedNMSPlugin.h
+++ b/plugin/batchedNMSPlugin/batchedNMSPlugin.h
@@ -88,7 +88,6 @@ private:
     int numPriors{};
     std::string mNamespace;
     bool mClipBoxes{};
-    const char* mPluginNamespace;
 };
 
 class BatchedNMSPluginCreator : public BaseCreator


### PR DESCRIPTION
Signed-off-by: Rajeev Rao <rajeevrao@nvidia.com>