### PR TITLE
Use torch 1.4.0 for exporting Tacotron2 ONNX models

### DIFF
--- a/demo/Tacotron2/scripts/install_prerequisites.sh
+++ b/demo/Tacotron2/scripts/install_prerequisites.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-pip3 install numba==0.48 torch==1.5.1
+pip3 install numba==0.48 torch==1.4.0
 pip3 install -r requirements.txt
 sudo apt-get install -y libsndfile1
 


### PR DESCRIPTION
This is to workaround type error in validation of Tacotron2
decoder generated with torch 1.5.x

Signed-off-by: Rajeev Rao <rajeevrao@nvidia.com>