### PR TITLE
Set CUDA_INSTALL_DIR if it is not set by cmake build command

### DIFF
--- a/samples/CMakeSamplesTemplate.txt
+++ b/samples/CMakeSamplesTemplate.txt
@@ -27,7 +27,7 @@ set(TARGET_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 get_filename_component(SAMPLES_DIR ../../ ABSOLUTE)
 get_filename_component(SAMPLE_DIR_NAME ${TARGET_DIR} NAME)
 
-set(CUDA_INSTALL_DIR /usr/local/cuda)
+set_ifndef(CUDA_INSTALL_DIR /usr/local/cuda)
 
 # SAMPLES_COMMON_SOURCES
 set(SAMPLES_COMMON_SOURCES


### PR DESCRIPTION
Changed the way CUDA_INSTALL_DIR is being set in the CMakeLists files. It should be set to `/usr/local/cuda` only if it is not set to the specific directory explicitly. For e.g. In case of conda builds, usually cuda is installed at $CONDA_PREFIX, so if we specify the CUDA_INSTALL_DIR through cmake argument `-DCUDA_INSTALL_DIR`, it should be used instead of the default one.