### PR TITLE
[FIX] Function Name Mismatch in trtexec:tracer.py

### DIFF
--- a/samples/opensource/trtexec/prn_utils.py
+++ b/samples/opensource/trtexec/prn_utils.py
@@ -26,7 +26,7 @@ from __future__ import print_function
 
 
 
-def combineDescriptions(prolog, features, descriptions):
+def combine_descriptions(prolog, features, descriptions):
     ''' Combine features with their descriptions '''
 
     fullDescription = prolog

--- a/samples/opensource/trtexec/prn_utils.py
+++ b/samples/opensource/trtexec/prn_utils.py
@@ -26,7 +26,7 @@ from __future__ import print_function
 
 
 
-def combine_descriptions(prolog, features, descriptions):
+def combineDescriptions(prolog, features, descriptions):
     ''' Combine features with their descriptions '''
 
     fullDescription = prolog

--- a/samples/opensource/trtexec/tracer.py
+++ b/samples/opensource/trtexec/tracer.py
@@ -45,7 +45,7 @@ defaultMetrics = ",".join(allMetrics)
 descriptions = ['start input', 'end input', 'start compute', 'end compute', 'start output',
                 'end output', 'input', 'compute', 'output', 'latency', 'end to end latency']
 
-metricsDescription = pu.combine_descriptions('Possible metrics (all in ms) are:',
+metricsDescription = pu.combineDescriptions('Possible metrics (all in ms) are:',
                                              allMetrics, descriptions)
 
 


### PR DESCRIPTION
when I run 
`$ python3 tracer.py trace.json` like in trtexec's readme file.

I encountered an error like below:

`Traceback (most recent call last):
  File "tracer.py", line 48, in <module>
    metricsDescription = pu.combine_descriptions('Possible metrics (all in ms) are:',
AttributeError: module 'prn_utils' has no attribute 'combine_descriptions'`

this error caused by mismatching function name.
prn_util's function name was 'combineDescriptions'
so I changed it 'combine_descriptions'

after this process, 
tracer.py works well.