### PR TITLE
saving learned amax as a part of state dict

### DIFF
--- a/tools/pytorch-quantization/pytorch_quantization/nn/modules/tensor_quantizer.py
+++ b/tools/pytorch-quantization/pytorch_quantization/nn/modules/tensor_quantizer.py
@@ -87,6 +87,10 @@ class TensorQuantizer(nn.Module):
 
         if quant_desc.amax is not None:
             self.register_buffer('_amax', torch.tensor(quant_desc.amax))
+        
+        ##dynamic amax needs to be stored as a part of state dict to be used at inference time to map dynamic range to
+        # TRT layer
+        self.register_buffer('learned_amax',torch.tensor(1))
 
         # Clip module consumes a lot of memory, so only create it if learn_amax is True
         if self._learn_amax:
@@ -273,6 +277,7 @@ class TensorQuantizer(nn.Module):
         if self._scale_amax is not None:
             amax = amax.detach() * self._scale_amax
 
+        self.learned_amax = amax
         return amax
 
     def _fb_fake_quant(self, inputs, amax):


### PR DESCRIPTION
Hi there 

I am trying to use nvidia QAT library with no calibration to quantize the model and create a TRT engine. 

Since TRT only supports scale quantization with zero point = 0 , I need `amax` to calculate dynamic range and map it to TRT layer. 

However, I realized that when amax is being calculated dynamically, it is not stored as a part of state dict. This PR helps in storing dynamic amax. 

Here is the path to TRT engine for [reference](https://github.com/NVIDIA-AI-IOT/torch2trt/tree/dba95d430c59ed5fbfb74c9359a43fcf0ef12169/torch2trt/examples): 