### PR TITLE
Add FP16 support to batchedNMSPlugin

### DIFF
--- a/plugin/batchedNMSPlugin/batchedNMSInference.cu
+++ b/plugin/batchedNMSPlugin/batchedNMSInference.cu
@@ -77,7 +77,7 @@ pluginStatus_t nmsInference(cudaStream_t stream, const int N, const int perBatch
      */
     const int numScores = N * perBatchScoresSize;
     size_t totalScoresSize = detectionForwardPreNMSSize(N, perBatchScoresSize);
-    if(DT_BBOX == DataType::kHALF) totalScoresSize /= 2; // detectionForwardPreNMSSize is implemented in terms of kFLOAT
+    if(DT_SCORE == DataType::kHALF) totalScoresSize /= 2; // detectionForwardPreNMSSize is implemented in terms of kFLOAT
     void* scores = nextWorkspacePtr((int8_t*) bboxPermute, bboxPermuteSize);
 
     // need a conf_scores
@@ -93,7 +93,7 @@ pluginStatus_t nmsInference(cudaStream_t stream, const int N, const int perBatch
     void* indices = nextWorkspacePtr((int8_t*) scores, totalScoresSize);
 
     size_t postNMSScoresSize = detectionForwardPostNMSSize(N, numClasses, topK);
-    if(DT_BBOX == DataType::kHALF) postNMSScoresSize /= 2; // detectionForwardPostNMSSize is implemented in terms of kFLOAT
+    if(DT_SCORE == DataType::kHALF) postNMSScoresSize /= 2; // detectionForwardPostNMSSize is implemented in terms of kFLOAT
     size_t postNMSIndicesSize = detectionForwardPostNMSSize(N, numClasses, topK); // indices are full int32
     void* postNMSScores = nextWorkspacePtr((int8_t*) indices, indicesSize);
     void* postNMSIndices = nextWorkspacePtr((int8_t*) postNMSScores, postNMSScoresSize);

--- a/plugin/batchedNMSPlugin/batchedNMSInference.cu
+++ b/plugin/batchedNMSPlugin/batchedNMSInference.cu
@@ -36,7 +36,7 @@ pluginStatus_t nmsInference(cudaStream_t stream, const int N, const int perBatch
      */
     const int numLocClasses = shareLocation ? 1 : numClasses;
 
-    size_t bboxDataSize = detectionForwardBBoxDataSize(N, perBatchBoxesSize, DataType::kFLOAT);
+    size_t bboxDataSize = detectionForwardBBoxDataSize(N, perBatchBoxesSize, DT_BBOX);
     void* bboxDataRaw = workspace;
     cudaMemcpyAsync(bboxDataRaw, locData, bboxDataSize, cudaMemcpyDeviceToDevice, stream);
     pluginStatus_t status;
@@ -47,7 +47,7 @@ pluginStatus_t nmsInference(cudaStream_t stream, const int N, const int perBatch
      */
     // float for now
     void* bboxData;
-    size_t bboxPermuteSize = detectionForwardBBoxPermuteSize(shareLocation, N, perBatchBoxesSize, DataType::kFLOAT);
+    size_t bboxPermuteSize = detectionForwardBBoxPermuteSize(shareLocation, N, perBatchBoxesSize, DT_BBOX);
     void* bboxPermute = nextWorkspacePtr((int8_t*) bboxDataRaw, bboxDataSize);
 
     /*
@@ -58,7 +58,7 @@ pluginStatus_t nmsInference(cudaStream_t stream, const int N, const int perBatch
     if (!shareLocation)
     {
         status = permuteData(
-            stream, locCount, numLocClasses, numPredsPerClass, 4, DataType::kFLOAT, false, bboxDataRaw, bboxPermute);
+            stream, locCount, numLocClasses, numPredsPerClass, 4, DT_BBOX, false, bboxDataRaw, bboxPermute);
         ASSERT_FAILURE(status == STATUS_SUCCESS);
         bboxData = bboxPermute;
     }
@@ -77,6 +77,7 @@ pluginStatus_t nmsInference(cudaStream_t stream, const int N, const int perBatch
      */
     const int numScores = N * perBatchScoresSize;
     size_t totalScoresSize = detectionForwardPreNMSSize(N, perBatchScoresSize);
+    if(DT_BBOX == DataType::kHALF) totalScoresSize /= 2; // detectionForwardPreNMSSize is implemented in terms of kFLOAT
     void* scores = nextWorkspacePtr((int8_t*) bboxPermute, bboxPermuteSize);
 
     // need a conf_scores
@@ -85,21 +86,22 @@ pluginStatus_t nmsInference(cudaStream_t stream, const int N, const int perBatch
      * [batch_size, numClasses, numPredsPerClass, 1]
      */
     status = permuteData(
-        stream, numScores, numClasses, numPredsPerClass, 1, DataType::kFLOAT, confSigmoid, confData, scores);
+        stream, numScores, numClasses, numPredsPerClass, 1, DT_BBOX, confSigmoid, confData, scores);
     ASSERT_FAILURE(status == STATUS_SUCCESS);
 
     size_t indicesSize = detectionForwardPreNMSSize(N, perBatchScoresSize);
     void* indices = nextWorkspacePtr((int8_t*) scores, totalScoresSize);
 
     size_t postNMSScoresSize = detectionForwardPostNMSSize(N, numClasses, topK);
-    size_t postNMSIndicesSize = detectionForwardPostNMSSize(N, numClasses, topK);
+    if(DT_BBOX == DataType::kHALF) postNMSScoresSize /= 2; // detectionForwardPostNMSSize is implemented in terms of kFLOAT
+    size_t postNMSIndicesSize = detectionForwardPostNMSSize(N, numClasses, topK); // indices are full int32
     void* postNMSScores = nextWorkspacePtr((int8_t*) indices, indicesSize);
     void* postNMSIndices = nextWorkspacePtr((int8_t*) postNMSScores, postNMSScoresSize);
 
     void* sortingWorkspace = nextWorkspacePtr((int8_t*) postNMSIndices, postNMSIndicesSize);
     // Sort the scores so that the following NMS could be applied.
     status = sortScoresPerClass(stream, N, numClasses, numPredsPerClass, backgroundLabelId, scoreThreshold,
-        DataType::kFLOAT, scores, indices, sortingWorkspace);
+        DT_SCORE, scores, indices, sortingWorkspace);
 
     ASSERT_FAILURE(status == STATUS_SUCCESS);
 
@@ -108,18 +110,18 @@ pluginStatus_t nmsInference(cudaStream_t stream, const int N, const int perBatch
     bool flipXY = true;
     // NMS
     status = allClassNMS(stream, N, numClasses, numPredsPerClass, topK, iouThreshold, shareLocation, isNormalized,
-        DataType::kFLOAT, DataType::kFLOAT, bboxData, scores, indices, postNMSScores, postNMSIndices, flipXY);
+        DT_SCORE, DT_BBOX, bboxData, scores, indices, postNMSScores, postNMSIndices, flipXY);
     ASSERT_FAILURE(status == STATUS_SUCCESS);
 
     // Sort the bounding boxes after NMS using scores
-    status = sortScoresPerImage(stream, N, numClasses * topK, DataType::kFLOAT, postNMSScores, postNMSIndices, scores,
+    status = sortScoresPerImage(stream, N, numClasses * topK, DT_SCORE, postNMSScores, postNMSIndices, scores,
         indices, sortingWorkspace);
 
     ASSERT_FAILURE(status == STATUS_SUCCESS);
 
     // Gather data from the sorted bounding boxes after NMS
-    status = gatherNMSOutputs(stream, shareLocation, N, numPredsPerClass, numClasses, topK, keepTopK, DataType::kFLOAT,
-        DataType::kFLOAT, indices, scores, bboxData, keepCount, nmsedBoxes, nmsedScores, nmsedClasses, clipBoxes);
+    status = gatherNMSOutputs(stream, shareLocation, N, numPredsPerClass, numClasses, topK, keepTopK, DT_BBOX,
+        DT_SCORE, indices, scores, bboxData, keepCount, nmsedBoxes, nmsedScores, nmsedClasses, clipBoxes);
     ASSERT_FAILURE(status == STATUS_SUCCESS);
 
     return STATUS_SUCCESS;

--- a/plugin/batchedNMSPlugin/batchedNMSPlugin.cpp
+++ b/plugin/batchedNMSPlugin/batchedNMSPlugin.cpp
@@ -248,7 +248,7 @@ int BatchedNMSDynamicPlugin::enqueue(const PluginTensorDesc* inputDesc, const Pl
 size_t BatchedNMSPlugin::getSerializationSize() const
 {
     // NMSParameters, boxesSize,scoresSize,numPriors
-    return sizeof(NMSParameters) + sizeof(int) * 3 + sizeof(bool);
+    return sizeof(NMSParameters) + sizeof(int) * 3 + sizeof(bool) + sizeof(DataType);
 }
 
 void BatchedNMSPlugin::serialize(void* buffer) const
@@ -266,7 +266,7 @@ void BatchedNMSPlugin::serialize(void* buffer) const
 size_t BatchedNMSDynamicPlugin::getSerializationSize() const
 {
     // NMSParameters, boxesSize,scoresSize,numPriors
-    return sizeof(NMSParameters) + sizeof(int) * 3 + sizeof(bool);
+    return sizeof(NMSParameters) + sizeof(int) * 3 + sizeof(bool) + sizeof(DataType);
 }
 
 void BatchedNMSDynamicPlugin::serialize(void* buffer) const

--- a/plugin/batchedNMSPlugin/batchedNMSPlugin.h
+++ b/plugin/batchedNMSPlugin/batchedNMSPlugin.h
@@ -70,6 +70,7 @@ private:
     int numPriors{};
     std::string mNamespace;
     bool mClipBoxes{};
+    DataType mPrecision;
 };
 
 class BatchedNMSDynamicPlugin : public IPluginV2DynamicExt
@@ -114,6 +115,7 @@ private:
     int numPriors{};
     std::string mNamespace;
     bool mClipBoxes{};
+    DataType mPrecision;
 };
 
 class BatchedNMSBasePluginCreator : public BaseCreator

--- a/plugin/common/kernels/allClassNMS.cu
+++ b/plugin/common/kernels/allClassNMS.cu
@@ -23,7 +23,7 @@ __device__ float bboxSize(
     const Bbox<T_BBOX>& bbox,
     const bool normalized)
 {
-    if (bbox.xmax < bbox.xmin || bbox.ymax < bbox.ymin)
+    if (float(bbox.xmax) < float(bbox.xmin) || float(bbox.ymax) < float(bbox.ymin))
     {
         // If bbox is invalid (e.g. xmax < xmin or ymax < ymin), return 0.
         return 0;
@@ -74,7 +74,10 @@ __device__ void intersectBbox<__half>(
     const Bbox<__half>& bbox2,
     Bbox<__half>* intersect_bbox)
 {
-    if (bbox2.xmin > bbox1.xmax || bbox2.xmax < bbox1.xmin || bbox2.ymin > bbox1.ymax || bbox2.ymax < bbox1.ymin)
+    if (float(bbox2.xmin) > float(bbox1.xmax)
+        || float(bbox2.xmax) < float(bbox1.xmin)
+        || float(bbox2.ymin) > float(bbox1.ymax)
+        || float(bbox2.ymax) < float(bbox1.ymin))
     {
         // Return [0, 0, 0, 0] if there is no intersection.
         intersect_bbox->xmin = __half(0);
@@ -131,13 +134,13 @@ __device__ float jaccardOverlap(
     float intersect_width, intersect_height;
     if (normalized)
     {
-        intersect_width = intersect_bbox.xmax - intersect_bbox.xmin;
-        intersect_height = intersect_bbox.ymax - intersect_bbox.ymin;
+        intersect_width = float(intersect_bbox.xmax) - float(intersect_bbox.xmin);
+        intersect_height = float(intersect_bbox.ymax) - float(intersect_bbox.ymin);
     }
     else
     {
-        intersect_width = intersect_bbox.xmax - intersect_bbox.xmin + T_BBOX(1);
-        intersect_height = intersect_bbox.ymax - intersect_bbox.ymin + T_BBOX(1);
+        intersect_width = float(intersect_bbox.xmax) - float(intersect_bbox.xmin) + float(T_BBOX(1));
+        intersect_height = float(intersect_bbox.ymax) - float(intersect_bbox.ymin) + float(T_BBOX(1));
     }
     if (intersect_width > 0 && intersect_height > 0)
     {

--- a/plugin/common/kernels/permuteData.cu
+++ b/plugin/common/kernels/permuteData.cu
@@ -95,8 +95,10 @@ struct pdLaunchConfig
     }
 };
 
-static std::array<pdLaunchConfig, 1> pdLCOptions = {
-  pdLaunchConfig(DataType::kFLOAT, permuteData_gpu<float>)};
+static std::array<pdLaunchConfig, 2> pdLCOptions = {
+  pdLaunchConfig(DataType::kFLOAT, permuteData_gpu<float>),
+  pdLaunchConfig(DataType::kHALF, permuteData_gpu<__half>)
+};
 
 pluginStatus_t permuteData(cudaStream_t stream,
                         const int nthreads,

--- a/plugin/common/kernels/sortScoresPerClass.cu
+++ b/plugin/common/kernels/sortScoresPerClass.cu
@@ -57,7 +57,7 @@ __launch_bounds__(nthds_per_cta)
             // "Clear" scores lower than threshold
             else
             {
-                if (score > confidence_threshold)
+                if (float(score) > confidence_threshold)
                 {
                     temp_scores[targetIdx] = score;
                     temp_idx[targetIdx] = cur_idx + i * numPredsPerBatch;
@@ -157,8 +157,10 @@ struct sspcLaunchConfig
     }
 };
 
-static std::array<sspcLaunchConfig, 1> sspcLCOptions = {
-    sspcLaunchConfig(DataType::kFLOAT, sortScoresPerClass_gpu<float>)};
+static std::array<sspcLaunchConfig, 2> sspcLCOptions = {
+    sspcLaunchConfig(DataType::kFLOAT, sortScoresPerClass_gpu<float>),
+    sspcLaunchConfig(DataType::kHALF, sortScoresPerClass_gpu<__half>)
+};
 
 pluginStatus_t sortScoresPerClass(
     cudaStream_t stream,
@@ -206,6 +208,10 @@ size_t sortScoresPerClassWorkspaceSize(
     if (DT_CONF == DataType::kFLOAT)
     {
         wss[3] = cubSortPairsWorkspaceSize<float, int>(arrayLen, num * num_classes); // cub workspace
+    }
+    else if (DT_CONF == DataType::kHALF)
+    {
+        wss[3] = cubSortPairsWorkspaceSize<__half, int>(arrayLen, num * num_classes); // cub workspace
     }
     else
     {

--- a/plugin/common/kernels/sortScoresPerClass.cu
+++ b/plugin/common/kernels/sortScoresPerClass.cu
@@ -50,9 +50,9 @@ __launch_bounds__(nthds_per_cta)
             {
                 // Set scores to 0
                 // Set label = -1
-                temp_scores[targetIdx] = 0.0f;
+                temp_scores[targetIdx] = 0.f;
                 temp_idx[targetIdx] = -1;
-                conf_scores_gpu[targetIdx] = 0.0f;
+                conf_scores_gpu[targetIdx] = 0.f;
             }
             // "Clear" scores lower than threshold
             else
@@ -66,9 +66,9 @@ __launch_bounds__(nthds_per_cta)
                 {
                     // Set scores to 0
                     // Set label = -1
-                    temp_scores[targetIdx] = 0.0f;
+                    temp_scores[targetIdx] = 0.f;
                     temp_idx[targetIdx] = -1;
-                    conf_scores_gpu[targetIdx] = 0.0f;
+                    conf_scores_gpu[targetIdx] = 0.f;
                     // TODO: HERE writing memory too many times
                 }
             }

--- a/plugin/common/kernels/sortScoresPerImage.cu
+++ b/plugin/common/kernels/sortScoresPerImage.cu
@@ -78,8 +78,10 @@ struct sspiLaunchConfig
     }
 };
 
-static std::array<sspiLaunchConfig, 1> sspiLCOptions = {
-    sspiLaunchConfig(DataType::kFLOAT, sortScoresPerImage_gpu<float>)};
+static std::array<sspiLaunchConfig, 2> sspiLCOptions = {
+    sspiLaunchConfig(DataType::kFLOAT, sortScoresPerImage_gpu<float>),
+    sspiLaunchConfig(DataType::kHALF, sortScoresPerImage_gpu<__half>),
+};
 
 pluginStatus_t sortScoresPerImage(
     cudaStream_t stream,
@@ -122,6 +124,10 @@ size_t sortScoresPerImageWorkspaceSize(
     if (DT_SCORE == DataType::kFLOAT)
     {
         wss[1] = cubSortPairsWorkspaceSize<float, int>(arrayLen, num_images); // cub workspace
+    }
+    else if (DT_SCORE == DataType::kHALF)
+    {
+        wss[1] = cubSortPairsWorkspaceSize<__half, int>(arrayLen, num_images); // cub workspace
     }
     else
     {

--- a/plugin/common/nmsHelper.cpp
+++ b/plugin/common/nmsHelper.cpp
@@ -32,7 +32,7 @@ size_t detectionForwardBBoxDataSize(int N, int C1, DataType DT_BBOX)
         return N * C1 * sizeof(__half);
     }
 
-    printf("Only FP32 type bounding boxes are supported.\n");
+    printf("Only FP32/FP16 type bounding boxes are supported.\n");
     return (size_t) -1;
 }
 
@@ -47,7 +47,7 @@ size_t detectionForwardBBoxPermuteSize(bool shareLocation, int N, int C1, DataTy
         return shareLocation ? 0 : N * C1 * sizeof(__half);
     }
 
-    printf("Only FP32 type bounding boxes are supported.\n");
+    printf("Only FP32/FP16 type bounding boxes are supported.\n");
     return (size_t) -1;
 }
 

--- a/plugin/common/nmsHelper.cpp
+++ b/plugin/common/nmsHelper.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "plugin.h"
+#include "cuda_fp16.h"
 #include <algorithm>
 
 using namespace nvinfer1;
@@ -25,6 +26,10 @@ size_t detectionForwardBBoxDataSize(int N, int C1, DataType DT_BBOX)
     if (DT_BBOX == DataType::kFLOAT)
     {
         return N * C1 * sizeof(float);
+    }
+    if (DT_BBOX == DataType::kHALF)
+    {
+        return N * C1 * sizeof(__half);
     }
 
     printf("Only FP32 type bounding boxes are supported.\n");
@@ -37,6 +42,11 @@ size_t detectionForwardBBoxPermuteSize(bool shareLocation, int N, int C1, DataTy
     {
         return shareLocation ? 0 : N * C1 * sizeof(float);
     }
+    if (DT_BBOX == DataType::kHALF)
+    {
+        return shareLocation ? 0 : N * C1 * sizeof(__half);
+    }
+
     printf("Only FP32 type bounding boxes are supported.\n");
     return (size_t) -1;
 }

--- a/plugin/generateDetectionPlugin/generateDetectionPlugin.h
+++ b/plugin/generateDetectionPlugin/generateDetectionPlugin.h
@@ -36,7 +36,7 @@ namespace plugin
 class GenerateDetection : public IPluginV2Ext
 {
 public:
-    GenerateDetection(int num_classes, int keep_topk, float score_threshold, float iou_threshold);
+    GenerateDetection(int num_classes, int keep_topk, float score_threshold, float iou_threshold, const nvinfer1::Dims& image_size);
 
     GenerateDetection(const void* data, size_t length);
 
@@ -103,6 +103,8 @@ private:
     nvinfer1::DataType mType;
     RefineNMSParameters mParam;
     std::shared_ptr<CudaBind<float>> mRegWeightDevice;
+
+    nvinfer1::Dims mImageSize;
 
     std::string mNameSpace;
 };

--- a/plugin/multilevelCropAndResizePlugin/multilevelCropAndResizePlugin.cpp
+++ b/plugin/multilevelCropAndResizePlugin/multilevelCropAndResizePlugin.cpp
@@ -17,6 +17,7 @@
 #include "multilevelCropAndResizePlugin.h"
 #include "plugin.h"
 #include <cuda_runtime_api.h>
+#include <algorithm>
 
 #include <fstream>
 
@@ -37,6 +38,7 @@ std::vector<PluginField> MultilevelCropAndResizePluginCreator::mPluginAttributes
 MultilevelCropAndResizePluginCreator::MultilevelCropAndResizePluginCreator()
 {
     mPluginAttributes.emplace_back(PluginField("pooled_size", nullptr, PluginFieldType::kINT32, 1));
+    mPluginAttributes.emplace_back(PluginField("image_size", nullptr, PluginFieldType::kINT32, 3));
 
     mFC.nbFields = mPluginAttributes.size();
     mFC.fields = mPluginAttributes.data();
@@ -59,6 +61,7 @@ const PluginFieldCollection* MultilevelCropAndResizePluginCreator::getFieldNames
 
 IPluginV2Ext* MultilevelCropAndResizePluginCreator::createPlugin(const char* name, const PluginFieldCollection* fc)
 {
+    auto image_size = TLTMaskRCNNConfig::IMAGE_SHAPE;
     const PluginField* fields = fc->fields;
     for (int i = 0; i < fc->nbFields; ++i)
     {
@@ -68,8 +71,14 @@ IPluginV2Ext* MultilevelCropAndResizePluginCreator::createPlugin(const char* nam
             assert(fields[i].type == PluginFieldType::kINT32);
             mPooledSize = *(static_cast<const int*>(fields[i].data));
         }
+        if (!strcmp(attrName, "image_size"))
+        {
+            assert(fields[i].type == PluginFieldType::kINT32);
+            const auto dims = static_cast<const int32_t*>(fields[i].data);
+            std::copy_n(dims, 3, image_size.d);
+        }
     }
-    return new MultilevelCropAndResize(mPooledSize);
+    return new MultilevelCropAndResize(mPooledSize, image_size);
 };
 
 IPluginV2Ext* MultilevelCropAndResizePluginCreator::deserializePlugin(const char* name, const void* data, size_t length)
@@ -77,14 +86,14 @@ IPluginV2Ext* MultilevelCropAndResizePluginCreator::deserializePlugin(const char
     return new MultilevelCropAndResize(data, length);
 };
 
-MultilevelCropAndResize::MultilevelCropAndResize(int pooled_size)
+MultilevelCropAndResize::MultilevelCropAndResize(int pooled_size, const nvinfer1::Dims& image_size)
     : mPooledSize({pooled_size, pooled_size})
 {
 
     assert(pooled_size > 0);
     // shape
-    mInputHeight = TLTMaskRCNNConfig::IMAGE_SHAPE.d[1];
-    mInputWidth = TLTMaskRCNNConfig::IMAGE_SHAPE.d[2];
+    mInputHeight = image_size.d[1];
+    mInputWidth = image_size.d[2];
     // Threshold to P3: Smaller -> P2
     mThresh = (224 * 224) / (4.0f);
 };

--- a/plugin/multilevelCropAndResizePlugin/multilevelCropAndResizePlugin.h
+++ b/plugin/multilevelCropAndResizePlugin/multilevelCropAndResizePlugin.h
@@ -36,7 +36,7 @@ namespace plugin
 class MultilevelCropAndResize : public IPluginV2Ext
 {
 public:
-    MultilevelCropAndResize(int pooled_size);
+    MultilevelCropAndResize(int pooled_size, const nvinfer1::Dims& image_size);
 
     MultilevelCropAndResize(const void* data, size_t length);
 

--- a/plugin/multilevelProposeROI/multilevelProposeROIPlugin.cpp
+++ b/plugin/multilevelProposeROI/multilevelProposeROIPlugin.cpp
@@ -19,6 +19,7 @@
 #include "tlt_mrcnn_config.h"
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <algorithm>
 #include <math.h>
 
 #include <fstream>
@@ -44,6 +45,7 @@ MultilevelProposeROIPluginCreator::MultilevelProposeROIPluginCreator()
     mPluginAttributes.emplace_back(PluginField("keep_topk", nullptr, PluginFieldType::kINT32, 1));
     mPluginAttributes.emplace_back(PluginField("fg_threshold", nullptr, PluginFieldType::kFLOAT32, 1));
     mPluginAttributes.emplace_back(PluginField("iou_threshold", nullptr, PluginFieldType::kFLOAT32, 1));
+    mPluginAttributes.emplace_back(PluginField("image_size", nullptr, PluginFieldType::kINT32, 3));
 
     mFC.nbFields = mPluginAttributes.size();
     mFC.fields = mPluginAttributes.data();
@@ -66,6 +68,7 @@ const PluginFieldCollection* MultilevelProposeROIPluginCreator::getFieldNames()
 
 IPluginV2Ext* MultilevelProposeROIPluginCreator::createPlugin(const char* name, const PluginFieldCollection* fc)
 {
+    auto image_size = TLTMaskRCNNConfig::IMAGE_SHAPE;
     const PluginField* fields = fc->fields;
     for (int i = 0; i < fc->nbFields; ++i)
     {
@@ -90,8 +93,14 @@ IPluginV2Ext* MultilevelProposeROIPluginCreator::createPlugin(const char* name, 
             assert(fields[i].type == PluginFieldType::kFLOAT32);
             mIOUThreshold = *(static_cast<const float*>(fields[i].data));
         }
+        if (!strcmp(attrName, "image_size"))
+        {
+            assert(fields[i].type == PluginFieldType::kINT32);
+            const auto dims = static_cast<const int32_t*>(fields[i].data);
+            std::copy_n(dims, 3, image_size.d);
+        }
     }
-    return new MultilevelProposeROI(mPreNMSTopK, mKeepTopK, mFGThreshold, mIOUThreshold);
+    return new MultilevelProposeROI(mPreNMSTopK, mKeepTopK, mFGThreshold, mIOUThreshold, image_size);
 };
 
 IPluginV2Ext* MultilevelProposeROIPluginCreator::deserializePlugin(const char* name, const void* data, size_t length)
@@ -99,11 +108,12 @@ IPluginV2Ext* MultilevelProposeROIPluginCreator::deserializePlugin(const char* n
     return new MultilevelProposeROI(data, length);
 };
 
-MultilevelProposeROI::MultilevelProposeROI(int prenms_topk, int keep_topk, float fg_threshold, float iou_threshold)
+MultilevelProposeROI::MultilevelProposeROI(int prenms_topk, int keep_topk, float fg_threshold, float iou_threshold, const nvinfer1::Dims image_size)
     : mPreNMSTopK(prenms_topk)
     , mKeepTopK(keep_topk)
     , mFGThreshold(fg_threshold)
     , mIOUThreshold(iou_threshold)
+    , mImageSize(image_size)
 {
     mBackgroundLabel = -1;
     assert(mPreNMSTopK > 0);
@@ -122,7 +132,7 @@ MultilevelProposeROI::MultilevelProposeROI(int prenms_topk, int keep_topk, float
 
     mFeatureCnt = TLTMaskRCNNConfig::MAX_LEVEL - TLTMaskRCNNConfig::MIN_LEVEL + 1;
 
-    generate_pyramid_anchors();
+    generate_pyramid_anchors(mImageSize);
 };
 
 int MultilevelProposeROI::getNbOutputs() const
@@ -225,7 +235,7 @@ const char* MultilevelProposeROI::getPluginNamespace() const
 
 size_t MultilevelProposeROI::getSerializationSize() const
 {
-    return sizeof(int) * 2 + sizeof(float) * 2 + sizeof(int) * (mFeatureCnt + 1);
+    return sizeof(int) * 2 + sizeof(float) * 2 + sizeof(int) * (mFeatureCnt + 1) + sizeof(nvinfer1::Dims);
 };
 
 void MultilevelProposeROI::serialize(void* buffer) const
@@ -240,6 +250,7 @@ void MultilevelProposeROI::serialize(void* buffer) const
     {
         write(d, mAnchorsCnt[i]);
     }
+    write(d, mImageSize);
     ASSERT(d == a + getSerializationSize());
 };
 
@@ -258,6 +269,7 @@ MultilevelProposeROI::MultilevelProposeROI(const void* data, size_t length)
     {
         mAnchorsCnt.push_back(read<int>(d));
     }
+    mImageSize = read<nvinfer1::Dims3>(d);
     ASSERT(d == a + length);
 
     mBackgroundLabel = -1;
@@ -274,7 +286,7 @@ MultilevelProposeROI::MultilevelProposeROI(const void* data, size_t length)
 
     mType = DataType::kFLOAT;
 
-    generate_pyramid_anchors();
+    generate_pyramid_anchors(mImageSize);
 };
 
 void MultilevelProposeROI::check_valid_inputs(const nvinfer1::Dims* inputs, int nbInputDims)
@@ -330,9 +342,9 @@ Dims MultilevelProposeROI::getOutputDimensions(int index, const Dims* inputs, in
     return proposals;
 }
 
-void MultilevelProposeROI::generate_pyramid_anchors()
+void MultilevelProposeROI::generate_pyramid_anchors(const nvinfer1::Dims& image_size)
 {
-    const auto image_dims = TLTMaskRCNNConfig::IMAGE_SHAPE;
+    const auto image_dims = image_size;
 
     const auto& anchor_scale = TLTMaskRCNNConfig::RPN_ANCHOR_SCALE;
     const auto& min_level = TLTMaskRCNNConfig::MIN_LEVEL;
@@ -390,8 +402,8 @@ int MultilevelProposeROI::enqueue(
         MultilevelProposeROIWorkSpace proposal_ws(batch_size, mAnchorsCnt[i], mPreNMSTopK, mParam, mType);
         status = MultilevelPropose(stream, batch_size, mAnchorsCnt[i], mPreNMSTopK,
             static_cast<float*>(mRegWeightDevice->mPtr),
-            static_cast<float>(TLTMaskRCNNConfig::IMAGE_SHAPE.d[1]), // Input Height
-            static_cast<float>(TLTMaskRCNNConfig::IMAGE_SHAPE.d[2]),
+            static_cast<float>(mImageSize.d[1]), // Input Height
+            static_cast<float>(mImageSize.d[2]),
             DataType::kFLOAT, // mType,
             mParam, proposal_ws, workspace + kernel_workspace_offset,
             inputs[2 * i + 1], // inputs[object_score],

--- a/plugin/multilevelProposeROI/multilevelProposeROIPlugin.h
+++ b/plugin/multilevelProposeROI/multilevelProposeROIPlugin.h
@@ -35,7 +35,7 @@ namespace plugin
 class MultilevelProposeROI : public IPluginV2Ext
 {
 public:
-    MultilevelProposeROI(int prenms_topk, int keep_topk, float fg_threshold, float iou_threshold);
+    MultilevelProposeROI(int prenms_topk, int keep_topk, float fg_threshold, float iou_threshold, const nvinfer1::Dims image_size);
 
     MultilevelProposeROI(const void* data, size_t length);
 
@@ -89,7 +89,7 @@ public:
 
 private:
     void check_valid_inputs(const nvinfer1::Dims* inputs, int nbInputDims);
-    void generate_pyramid_anchors();
+    void generate_pyramid_anchors(const nvinfer1::Dims& image_size);
 
     int mBackgroundLabel;
     int mPreNMSTopK;
@@ -110,6 +110,7 @@ private:
     float** mDeviceBboxes;
     std::shared_ptr<CudaBind<float>> mRegWeightDevice;
 
+    nvinfer1::Dims mImageSize;
     nvinfer1::DataType mType;
     RefineNMSParameters mParam;
 


### PR DESCRIPTION
Add support for float16 boxes and scores (but not mixed precision between boxes and scores).

Gives inference results within expected numerical tolerances using SSD300 and COCO2017 validation set. (As detailed here https://paulbridger.com/posts/tensorrt-object-detection-quantized/).

Despite the "#if __CUDA_ARCH__ >= 800" this has not been tested on Ampere, only Turing arch.
