### PR TITLE
Use right CMake variable for cu files in GroupNorm

### DIFF
--- a/plugin/groupNormalizationPlugin/CMakeLists.txt
+++ b/plugin/groupNormalizationPlugin/CMakeLists.txt
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-file(GLOB SRCS *.cpp *.cu)
+file(GLOB SRCS *.cpp)
 set(PLUGIN_SOURCES ${PLUGIN_SOURCES} ${SRCS})
 set(PLUGIN_SOURCES ${PLUGIN_SOURCES} PARENT_SCOPE)
+file(GLOB CU_SRCS *.cu)
+set(PLUGIN_CU_SOURCES ${PLUGIN_CU_SOURCES} ${CU_SRCS})
+set(PLUGIN_CU_SOURCES ${PLUGIN_CU_SOURCES} PARENT_SCOPE)


### PR DESCRIPTION
In groupNormalizationPlugin, the .cu files are not added to
PLUGIN_CU_SOURCES, contrary to other plugins.

This is problematic because the NVCC flags are not set correctly when
compiling those .cu files, e.g. GENCODES.

While this is not a direct issue for this plugin in particular, it
should be fixed as the documentation refers to it for building new
plugings.

Signed-off-by: Mickaël Seznec <mickael.seznec@gmail.com>