### PR TITLE
Fix a computational problem of scaledSoftmax.

### DIFF
--- a/plugin/common/common.cuh
+++ b/plugin/common/common.cuh
@@ -326,7 +326,6 @@ template <typename T, unsigned TPB>
 __device__ inline void scaledSoftmax(
     const int ld, const int lastValid, const float rsqrtHeadSize, const T* input, T* output)
 {
-    
     using BlockReduce = cub::BlockReduce<float, TPB>;
     __shared__ typename BlockReduce::TempStorage tmpStorage;
 
@@ -343,7 +342,6 @@ __device__ inline void scaledSoftmax(
     {
         threadData = 0;
     }
-
     for (int i = threadIdx.x; i < lastValid; i += TPB)
     {
         const int idx = offset + i;

--- a/plugin/common/common.cuh
+++ b/plugin/common/common.cuh
@@ -35,6 +35,7 @@ __device__ inline T rsqrt(const T& x);
 template <typename T>
 __device__ inline T exp(const T& x);
 
+
 // Float32 Operations
 template <>
 __device__ inline float tanh(const float& x)
@@ -54,10 +55,12 @@ __device__ inline float exp(const float& x)
     return expf(x);
 }
 
+
 __device__ inline kv_float operator+(const kv_float& a, const kv_float& b)
 {
     return kv_float(a.key + b.key, a.value + b.value);
 }
+
 
 // Half Operations
 
@@ -81,6 +84,7 @@ __device__ inline T operator+(const T& a, const T& b);
 template <typename T>
 __device__ inline T operator*(const T& a, const T& b);
 
+
 template <>
 __device__ inline half2 operator+(const half2& a, const half2& b)
 {
@@ -99,8 +103,10 @@ __device__ inline half2 operator*(const half2& a, const half2& b)
 template <typename T>
 __device__ inline T operator+(const T& a, const T& b);
 
+
 template <typename T>
 __device__ inline T operator/(const T& a, const T& b);
+
 
 template <typename T>
 __device__ inline T& operator+=(T& a, const T& b);
@@ -110,6 +116,7 @@ __device__ inline T operator-(const T& a, const T& b);
 
 template <typename T>
 __device__ inline T operator*(const T& a, const T& b);
+
 
 template <>
 __device__ inline half operator+(const half& a, const half& b)
@@ -193,6 +200,7 @@ __device__ inline kv_half2 operator+(const kv_half2& a, const kv_half2& b)
 {
     return kv_half2(__hadd2_with_fallback(a.key, b.key), __hadd2_with_fallback(a.value, b.value));
 }
+
 
 // Helper Functions
 
@@ -318,6 +326,7 @@ template <typename T, unsigned TPB>
 __device__ inline void scaledSoftmax(
     const int ld, const int lastValid, const float rsqrtHeadSize, const T* input, T* output)
 {
+    
     using BlockReduce = cub::BlockReduce<float, TPB>;
     __shared__ typename BlockReduce::TempStorage tmpStorage;
 

--- a/plugin/common/common.cuh
+++ b/plugin/common/common.cuh
@@ -349,6 +349,7 @@ __device__ inline void scaledSoftmax(
     __syncthreads();
 
     threadData = 0;
+
     for (int i = threadIdx.x; i < lastValid; i += TPB)
     {
         const int idx = offset + i;


### PR DESCRIPTION
**Problem**: The original implementation results in wrong results of sum of softmax such that the results of BERT models (128 < seq_len < 384 and seq_len > 384) are very large or even 'nan', especially for FP16 mode.
**Solution**: This implementation fix the computational problem such that the results of BERT models (128 < seq_len < 384 and seq_len > 384) become correct.

Signed-off-by: yuanzexi <hiyuanzexi@outlook.com>