### PR TITLE
[BERT demo]modify optimization profile setting to be compatible with BERT

### DIFF
--- a/demo/BERT/builder.py
+++ b/demo/BERT/builder.py
@@ -523,23 +523,26 @@ def emb_layernorm(builder, network, config, weights_dict, builder_config, sequen
     # Specify profiles for the batch sizes we're interested in.
     # Make sure the profile also works for all sizes not covered by the previous profile.
 
+    max_batch_size = max(batch_sizes)
     for batch_size in sorted(batch_sizes):
         if len(sequence_lengths) == 1:
             profile = builder.create_optimization_profile()
             min_shape = (1, sequence_lengths[0])
             shape = (batch_size, sequence_lengths[0])
-            profile.set_shape("input_ids", min=min_shape, opt=shape, max=shape)
-            profile.set_shape("segment_ids", min=min_shape, opt=shape, max=shape)
-            profile.set_shape("input_mask", min=min_shape, opt=shape, max=shape)
+            max_shape = (max_batch_size, sequence_lengths[0])
+            profile.set_shape("input_ids", min=min_shape, opt=shape, max=max_shape)
+            profile.set_shape("segment_ids", min=min_shape, opt=shape, max=max_shape)
+            profile.set_shape("input_mask", min=min_shape, opt=shape, max=max_shape)
             builder_config.add_optimization_profile(profile)
         else:
             for sequence_length in sorted(sequence_lengths):
                 profile = builder.create_optimization_profile()
                 min_shape = (1, sequence_length)
                 shape = (batch_size, sequence_length)
-                profile.set_shape("input_ids", min=min_shape, opt=shape, max=shape)
-                profile.set_shape("segment_ids", min=min_shape, opt=shape, max=shape)
-                profile.set_shape("input_mask", min=min_shape, opt=shape, max=shape)
+                max_shape = (max_batch_size, sequence_length)
+                profile.set_shape("input_ids", min=min_shape, opt=shape, max=max_shape)
+                profile.set_shape("segment_ids", min=min_shape, opt=shape, max=max_shape)
+                profile.set_shape("input_mask", min=min_shape, opt=shape, max=max_shape)
                 builder_config.add_optimization_profile(profile)
 
     wbeta = trt.PluginField("bert_embeddings_layernorm_beta", weights_dict["bert_embeddings_layernorm_beta"].numpy(), trt.PluginFieldType.FLOAT32)


### PR DESCRIPTION
Triton requires all profiles to share the same max batch size.

This commit shouldn't break inference code.