### PR TITLE
GHSA-cwv3-863g-39vx - do not specify tf1 in Polygraphy requirements file

### DIFF
--- a/tools/Polygraphy/README.md
+++ b/tools/Polygraphy/README.md
@@ -25,9 +25,8 @@ in various frameworks. It includes a [Python API](./polygraphy), and
 **NOTE:** It is strongly recommended to install the `colored` module for colored output
 from Polygraphy, as this can greatly improve readability.
 
-Each `backend` directory includes a `requirements.txt` file that specifies which packages
-it depends on. You can install the requirements for whichever backends you're interested in
-using:
+Most `backend` directories includes a `requirements.txt` file that specifies the minimum set of packages
+they depend on. You can install the requirements for whichever backends you're interested in using:
 
 ```bash
 python3 -m pip install -r polygraphy/backend/<name>/requirements.txt

--- a/tools/Polygraphy/polygraphy/backend/tf/README.md
+++ b/tools/Polygraphy/polygraphy/backend/tf/README.md
@@ -1,0 +1,1 @@
+NOTE: The `tf` backend currently only supports TensorFlow 1.X.

--- a/tools/Polygraphy/polygraphy/backend/tf/requirements.txt
+++ b/tools/Polygraphy/polygraphy/backend/tf/requirements.txt
@@ -1,1 +1,0 @@
-tensorflow<2.0


### PR DESCRIPTION
Signed-off-by: Rajeev Rao <rajeevrao@nvidia.com>