### PR TITLE
Make __init__.py depend on __file__ conditionally.

### DIFF
--- a/python/packaging/tensorrt/__init__.py
+++ b/python/packaging/tensorrt/__init__.py
@@ -28,9 +28,10 @@ def try_load(library):
 
 
 # Try loading all packaged libraries
-CURDIR = os.path.realpath(os.path.dirname(__file__))
-for lib in glob.iglob(os.path.join(CURDIR, "*.so*")):
-    try_load(lib)
+if "__file__" in globals():
+    CURDIR = os.path.realpath(os.path.dirname(__file__))
+    for lib in glob.iglob(os.path.join(CURDIR, "*.so*")):
+        try_load(lib)
 
 
 from .tensorrt import *


### PR DESCRIPTION
According to https://docs.python.org/3/reference/import.html#__file__ , `__file__` is an optional module attribute, and the its availability is decided by the import system. In the edge case where tensorrt is imported as a frozen module (https://docs.python.org/3/c-api/import.html#c.PyImport_ImportFrozenModuleObject), there seems no suitable `__file__` attribute to be assigned therefore in this case it's probably better to skip the library loading process.