### PR TITLE
Update compare_tf.py

### DIFF
--- a/samples/python/efficientdet/compare_tf.py
+++ b/samples/python/efficientdet/compare_tf.py
@@ -110,7 +110,7 @@ class TensorFlowInfer:
                 'ymax': boxes[0][n][2] * scale,
                 'xmax': boxes[0][n][3] * scale,
                 'score': scores[0][n],
-                'class': int(classes[0][n]) - 1,
+                'class': int(classes[0][n]),
             })
         return detections
 


### PR DESCRIPTION
TLDR; Fix classes range outputted by the model (-1~88 to 0~89).

There seemed to be an issue in `TensorFlowInfer`'s `infer` function in the [*compare_tf.py*](https://github.com/NVIDIA/TensorRT/blob/master/samples/python/efficientdet/compare_tf.py) script, more specifically [here](https://github.com/NVIDIA/TensorRT/blob/eb8442dba3c9e85ffb77e0d870d2e29adcb0a4aa/samples/python/efficientdet/compare_tf.py#L113): 
```python
def infer(self, batch, scales=None, nms_threshold=None):
    ...
    detections[0].append({
        ...
        'class': int(classes[0][n]) - 1,
    })
```

It should be:
```python
'class': int(classes[0][n]),
```

### How the bug was found
The bug was found by evaluating the model's performance (accuracy) with `TensorFlowInfer`'s class. With the original class, accuracy is close to 0%. After the fix, it's around the reported score (33.5% vs 33.6% reported).

This is due to the model outputting classes between 0 and 89, thus not needing `-1`. In fact, if a modification was to happen on this line, it would need to be `+1`, since the labels in the COCO dataset range from 1 to 90. The labels range has already been re-adjusted in [line 144](https://github.com/NVIDIA/TensorRT/blob/eb8442dba3c9e85ffb77e0d870d2e29adcb0a4aa/samples/python/efficientdet/compare_tf.py#L144), so only deleting `-1` is enough.