### PR TITLE
Fix a typo in trtexec/tracer.py

### DIFF
--- a/samples/trtexec/tracer.py
+++ b/samples/trtexec/tracer.py
@@ -45,7 +45,7 @@ defaultMetrics = ",".join(allMetrics)
 descriptions = ['start input', 'end input', 'start compute', 'end compute', 'start output',
                 'end output', 'input', 'compute', 'output', 'latency', 'end to end latency']
 
-metricsDescription = pu.combine_descriptions('Possible metrics (all in ms) are:',
+metricsDescription = pu.combineDescriptions('Possible metrics (all in ms) are:',
                                              allMetrics, descriptions)
 
 


### PR DESCRIPTION
Use camel case name of `combineDescriptions`. 