### PR TITLE
TensorRT OSS 21.10 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # TensorRT OSS Release Changelog
 
-## [21.10](https://github.com/NVIDIA/TensorRT/releases/tag/21.10) - TBD
+## [21.10](https://github.com/NVIDIA/TensorRT/releases/tag/21.10) - 2021-10-05
 ### Added
 - Benchmark script for demoBERT-Megatron
 - Dynamic Input Shape support for EfficientNMS plugin


### PR DESCRIPTION
Commit used by the [21.10](https://github.com/NVIDIA/TensorRT/releases/tag/21.10) TensorRT NGC container.

# Changelog
### Added
- Benchmark script for demoBERT-Megatron
- Dynamic Input Shape support for EfficientNMS plugin
- Support empty dimensions in ONNX
- INT32 and dynamic clips through elementwise in ONNX parser

### Changed
- Bump TensorRT version to 8.0.3.4
- Use static shape for only single batch single sequence input in demo/BERT
- Revert to using native FC layer in demo/BERT and FCPlugin only on older GPUs.
- Update demo/Tacotron2 for TensorRT 8.0
- Updates to TensorRT developer tools
  - Polygraphy [v0.33.0](tools/Polygraphy/CHANGELOG.md#v0330-2021-09-16)
    - Added various examples, a CLI User Guide and how-to guides.
    - Added experimental support for DLA.
    - Added a `data to-input` tool that can combine inputs/outputs created by `--save-inputs`/`--save-outputs`.
    - Added a `PluginRefRunner` which provides CPU reference implementations for TensorRT plugins
    - Made several performance improvements in the Polygraphy CUDA wrapper.
    - Removed the `to-json` tool which was used to convert Pickled data generated by Polygraphy 0.26.1 and older to JSON.
  - Bugfixes and documentation updates in pytorch-quantization toolkit.
- Bumped up package versions: tensorflow-gpu 2.5.1, pillow 8.3.2
- ONNX parser enhancements and bugfixes
  - Update ONNX submodule to v1.8.0
  - Update convDeconvMultiInput function to properly handle deconvs
  - Update RNN documentation
  - Update QDQ axis assertion
  - Fix bidirectional activation alpha and beta values
  - Fix opset10 `Resize`
  - Fix shape tensor unsqueeze
  - Mark BOOL tiles as unsupported
  - Remove unnecessary shape tensor checks

### Removed
- N/A