### PR TITLE
fix a little dims conflict in BatchedNMSPlugin

### DIFF
--- a/plugin/batchedNMSPlugin/batchedNMSPlugin.cpp
+++ b/plugin/batchedNMSPlugin/batchedNMSPlugin.cpp
@@ -157,7 +157,8 @@ Dims BatchedNMSPlugin::getOutputDimensions(int index, const Dims* inputs, int nb
         if (index == 0)
         {
             Dims dim0{};
-            dim0.nbDims = 0;
+            dim0.nbDims = 1;
+            dim0.d[0] = 1;
             return dim0;
         }
         // nmsed_boxes


### PR DESCRIPTION
I tried to use BatchedNMSPlugin in triton inference server, and found that "model output dimension must be integer >= 1, or -1 to indicate a variable-size dimension".

But if changing the config.pbtxt with first output dimension equal to 1, it causes another dimension mismatch error...

After the change show in this commit, nothing changed but triton inference server can work properly.