### PR TITLE
Adding a __iter__ binding to Dims

### DIFF
--- a/python/src/infer/pyFoundationalTypes.cpp
+++ b/python/src/infer/pyFoundationalTypes.cpp
@@ -239,6 +239,9 @@ void bindFoundationalTypes(py::module& m)
         .def("__eq__", lambdas::dimsEqual<Dims, py::tuple>)
         // These functions allow us to use Dims like an iterable.
         .def("__len__", lambdas::dims_len)
+        .def("__iter__", [](const Dims &s) {
+              return py::make_iterator(&s.d[0], &s.d[s.nbDims]); },
+              py::keep_alive<0, 1>())
         .def("__getitem__", lambdas::dims_getter)
         .def("__getitem__", lambdas::dims_getter_slice)
         .def("__setitem__", lambdas::dims_setter)


### PR DESCRIPTION
Adding a `__iter__` binding so that when we do tuple(Dims), python can construct the right iterator and knows where to stop instead of trial and error with exception catch. Previously, every time we do `tuple(Dims)`, it will trigger an exception, which will degrade the performance if it's in hot path, especially when we have a lot of `register_exception_translator` pybind handler registered (which does a lot of exception rethrow). 