### PR TITLE
Update correct path in t5.ipynb

### DIFF
--- a/demo/HuggingFace/notebooks/t5.ipynb
+++ b/demo/HuggingFace/notebooks/t5.ipynb
@@ -423,7 +423,7 @@
    "outputs": [],
    "source": [
     "tensorrt_model_path = './models/{}/tensorrt'.format(T5_VARIANT)\n",
-    "!mkdir -p tensorrt_model_path"
+    "!mkdir -p $tensorrt_model_path"
    ]
   },
   {


### PR DESCRIPTION
This code incorrectly creates a folder named "sensorrt_model_path".