### PR TITLE
[WIP] Fixed path in quantization classification_flow

### DIFF
--- a/tools/pytorch-quantization/examples/torchvision/classification_flow.py
+++ b/tools/pytorch-quantization/examples/torchvision/classification_flow.py
@@ -39,7 +39,7 @@ from pytorch_quantization import quant_modules
 
 import onnxruntime
 import numpy as np
-import models
+import models.classification as models
 
 from prettytable import PrettyTable
 


### PR DESCRIPTION
- One line fix solving the issue reported in [Issue 1938](https://github.com/NVIDIA/TensorRT/issues/1938)
- Fixed an import path in the pytorch-quantization tool.  Previously it
  was trying to import models directly, but all models are defined
  within models.classifcation, so it would always default to the
  torchvision versions.  As a result, the residual branch of ResNets was
  not being quantized.

Signed-off-by: Jeremy Malloch <jeremalloch@gmail.com>