### PR TITLE
Fix typos in EfficientDet jupyter notebook

### DIFF
--- a/demo/EfficientDet/notebooks/EfficientDet-TensorRT8.ipynb
+++ b/demo/EfficientDet/notebooks/EfficientDet-TensorRT8.ipynb
@@ -368,7 +368,7 @@
     "```\n",
     "* --saved_model /path/to/tf_model \n",
     "* --onnx /path/to/onnx.model\n",
-    "* --input_shape One of the input shapes corresponding to the model mentioned previously\n",
+    "* --input_size One of the input shapes corresponding to the model mentioned previously\n",
     "```"
    ]
   },
@@ -388,7 +388,7 @@
     "!python3 $TRT_OSSPATH/samples/python/efficientdet/create_onnx.py \\\n",
     "    --saved_model ./tf_model/ \\\n",
     "    --onnx ./onnx_model/model.onnx \\\n",
-    "    --input_shape '1,512,512,3'"
+    "    --input_size '512,512'"
    ]
   },
   {


### PR DESCRIPTION
The EfficientDet notebook example had incorrect argument name in the `create_onnx.py` invocation. This PR fixes it.

I've checked locally and with the fix below, the notebook runs successfully.

Signed-off-by: szalpal <mszolucha@nvidia.com>