### PR TITLE
fix GPG error: file:/var/cuda-repo-cross-aarch64-ubuntu2004-11-4-local

### DIFF
--- a/docker/ubuntu-cross-aarch64.Dockerfile
+++ b/docker/ubuntu-cross-aarch64.Dockerfile
@@ -74,8 +74,11 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
 
 # Install CUDA cross compile toolchain
-RUN dpkg -i /pdk_files/cuda-repo-cross-aarch64*.deb /pdk_files/cuda-repo-ubuntu*_amd64.deb \
-    && apt-get update \
+RUN dpkg -i /pdk_files/cuda-repo-cross-aarch64*.deb /pdk_files/cuda-repo-ubuntu*_amd64.deb 
+RUN cp /var/cuda-repo-cross-aarch64-ubuntu2004-11-4-local/cuda-045251B2-keyring.gpg  /usr/share/keyrings/
+RUN cp /var/cuda-repo-ubuntu2004-11-4-local/cuda-3231754F-keyring.gpg /usr/share/keyrings/
+
+RUN apt-get update \
     && apt-get install -y cuda-cross-aarch64 \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Following instructions on readme when building docker for Jetpack leads to following error

```
Step 24/33 : RUN dpkg -i /pdk_files/cuda-repo-cross-aarch64*.deb /pdk_files/cuda-repo-ubuntu*_amd64.deb     && apt-get update     && apt-get install -y cuda-cross-aarch64     && rm -rf /var/lib/apt/lists/*
 ---> Running in 903a9550204e
Selecting previously unselected package cuda-repo-cross-aarch64-ubuntu2004-11-4-local.
(Reading database ... 20878 files and directories currently installed.)
Preparing to unpack .../cuda-repo-cross-aarch64-ubuntu2004-11-4-local_11.4.14-1_all.deb ...
Unpacking cuda-repo-cross-aarch64-ubuntu2004-11-4-local (11.4.14-1) ...
Selecting previously unselected package cuda-repo-ubuntu2004-11-4-local.
Preparing to unpack .../cuda-repo-ubuntu2004-11-4-local_11.4.14-470.131-1_amd64.deb ...
Unpacking cuda-repo-ubuntu2004-11-4-local (11.4.14-470.131-1) ...
Setting up cuda-repo-cross-aarch64-ubuntu2004-11-4-local (11.4.14-1) ...

The public CUDA GPG key does not appear to be installed.
To install the key, run this command:
sudo cp /var/cuda-repo-cross-aarch64-ubuntu2004-11-4-local/cuda-045251B2-keyring.gpg /usr/share/keyrings/

Setting up cuda-repo-ubuntu2004-11-4-local (11.4.14-470.131-1) ...

The public CUDA GPG key does not appear to be installed.
To install the key, run this command:
sudo cp /var/cuda-repo-ubuntu2004-11-4-local/cuda-3231754F-keyring.gpg /usr/share/keyrings/

Get:1 file:/var/cuda-repo-cross-aarch64-ubuntu2004-11-4-local  InRelease [1575 B]
Get:2 file:/var/cuda-repo-ubuntu2004-11-4-local  InRelease [1575 B]
Get:1 file:/var/cuda-repo-cross-aarch64-ubuntu2004-11-4-local  InRelease [1575 B]
Get:2 file:/var/cuda-repo-ubuntu2004-11-4-local  InRelease [1575 B]
Err:1 file:/var/cuda-repo-cross-aarch64-ubuntu2004-11-4-local  InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 524C8D58045251B2
Err:2 file:/var/cuda-repo-ubuntu2004-11-4-local  InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 6FFBD47E3231754F
Get:3 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Hit:4 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease
Hit:5 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal InRelease
Hit:6 http://archive.ubuntu.com/ubuntu focal InRelease
Get:7 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [903 kB]
Get:8 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:9 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [2139 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Get:11 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1200 kB]
Get:12 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2600 kB]
Get:13 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [30.3 kB]
Reading package lists...
W: GPG error: file:/var/cuda-repo-cross-aarch64-ubuntu2004-11-4-local  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 524C8D58045251B2
E: The repository 'file:/var/cuda-repo-cross-aarch64-ubuntu2004-11-4-local  InRelease' is not signed.
W: GPG error: file:/var/cuda-repo-ubuntu2004-11-4-local  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 6FFBD47E3231754F
E: The repository 'file:/var/cuda-repo-ubuntu2004-11-4-local  InRelease' is not signed.
The command '/bin/sh -c dpkg -i /pdk_files/cuda-repo-cross-aarch64*.deb /pdk_files/cuda-repo-ubuntu*_amd64.deb     && apt-get update     && apt-get install -y cuda-cross-aarch64     && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```

By making these changes to the file, I am able to sucessfully build the docker