### PR TITLE
added back tensorflow python 3.6 support & fixed cuda 10.2 build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 onnx==1.10.2; python_version<"3.10"
 onnx==1.12.0; python_version=="3.10"
-tensorflow-gpu==2.9.1; (platform_machine=="x86_64" and sys.platform=="linux")
+tensorflow-gpu==2.9.1; (platform_machine=="x86_64" and sys.platform=="linux" and python_version>"3.6")
+tensorflow-gpu==2.5.1; (platform_machine=="x86_64" and sys.platform=="linux" and python_version<"3.7")
 onnxruntime==1.8.1; python_version<"3.10"
 onnxruntime==1.12.1; python_version=="3.10"
 -f https://download.pytorch.org/whl/cu113/torch_stable.html


### PR DESCRIPTION
The tensorflow version was upgraded to 2.9.1 to support python 3.10. However, this breaks Ubuntu 18.04 builds as it still uses python 3.6, also we can only build cuda 10.2 using Ubuntu 18.04 docker. So even though python 3.6 is EOL, we might still need this.
