### PR TITLE
Fix huggingface demo

### DIFF
--- a/demo/HuggingFace/BART/export.py
+++ b/demo/HuggingFace/BART/export.py
@@ -276,7 +276,7 @@ class BARTDecoderConverter(ModelFileConverter):
                     **inputs.get_torch_dynamic_axis_encoding(),
                     **outputs.get_torch_dynamic_axis_encoding(),
                 },
-                training=False,
+                # training=False,
                 **opt_args
             )
         else:
@@ -388,7 +388,7 @@ class BARTEncoderConverter(ModelFileConverter):
                 **inputs.get_torch_dynamic_axis_encoding(),
                 **outputs.get_torch_dynamic_axis_encoding(),
             },
-            training=False,
+            # training=False,
             **opt_args
         )
 

--- a/demo/HuggingFace/BART/onnxrt.py
+++ b/demo/HuggingFace/BART/onnxrt.py
@@ -311,7 +311,8 @@ class BARTONNXRT(OnnxRTCommand):
 
         return NetworkMetadata(
             variant=frameworks_parsed_metadata.variant,
-            precision=Precision(fp16=args.fp16, tf32=args.tf32),
+            precision=Precision(fp16=args.fp16),
+            # precision=Precision(fp16=args.fp16, tf32=args.tf32),
             other=frameworks_parsed_metadata.other,
         )
 

--- a/demo/HuggingFace/GPT2/export.py
+++ b/demo/HuggingFace/GPT2/export.py
@@ -24,8 +24,13 @@ from itertools import tee
 # tensorrt
 import tensorrt as trt
 
+# onnx
+import onnx
+
 # polygraphy
+from polygraphy.backend.onnx import fold_constants
 from polygraphy.backend.trt import Profile
+
 
 # torch
 import torch
@@ -169,7 +174,13 @@ class GPT2Converter(ModelFileConverter):
                 **inputs.get_torch_dynamic_axis_encoding(),
                 **outputs.get_torch_dynamic_axis_encoding(),
             },
-            training=False,
+            # training=False,
             **opt_args
         )
+        # Sanitizing due to slice ops
+        onnx_model = onnx.load(output_fpath)
+        folded = fold_constants(onnx_model)
+        onnx.save(folded, output_fpath)
+
         return GPT2ONNXFile(output_fpath, network_metadata)
+        # return GPT2ONNXFile(output_fpath, network_metadata)

--- a/demo/HuggingFace/NNDF/models.py
+++ b/demo/HuggingFace/NNDF/models.py
@@ -118,7 +118,7 @@ class ModelFileConverter:
             fp16=network_metadata.precision.fp16,
             max_workspace_size=result.DEFAULT_TRT_WORKSPACE_MB * 1024 * 1024,
             profiles=profiles,
-            precision_constraints=("obey" if result.use_obey_precision_constraints() else None),
+            # precision_constraints=("obey" if result.use_obey_precision_constraints() else None),
         )
 
         if G_LOGGER.level == G_LOGGER.DEBUG:

--- a/demo/HuggingFace/NNDF/tensorrt_utils.py
+++ b/demo/HuggingFace/NNDF/tensorrt_utils.py
@@ -170,7 +170,7 @@ class TRTNativeRunner:
 class PolygraphyOnnxRunner:
     def __init__(self, onnx_fpath: str, network_metadata: NetworkMetadata):
         self.network_metadata = network_metadata
-        self.trt_session = SessionFromOnnx(onnx_fpath)
+        self.trt_session = SessionFromOnnx(onnx_fpath, providers=["CUDAExecutionProvider"])
         self.trt_context = OnnxrtRunner(self.trt_session)
         self.trt_context.activate()
 

--- a/demo/HuggingFace/T5/export.py
+++ b/demo/HuggingFace/T5/export.py
@@ -258,7 +258,7 @@ class T5DecoderConverter(ModelFileConverter):
                 **inputs.get_torch_dynamic_axis_encoding(),
                 **outputs.get_torch_dynamic_axis_encoding(),
             },
-            training=False,
+            # training=False,
             **opt_args
         )
         
@@ -330,7 +330,7 @@ class T5EncoderConverter(ModelFileConverter):
                 **inputs.get_torch_dynamic_axis_encoding(),
                 **outputs.get_torch_dynamic_axis_encoding(),
             },
-            training=False,
+            # training=False,
             **opt_args
         )
         

--- a/demo/HuggingFace/requirements.txt
+++ b/demo/HuggingFace/requirements.txt
@@ -22,4 +22,5 @@ sentencepiece==0.1.95
 --extra-index-url https://pypi.ngc.nvidia.com
 onnx==1.9.0
 onnx_graphsurgeon
-polygraphy
+polygraphy>=0.42.2
+onnxruntime-gpu


### PR DESCRIPTION
Huggingface demo doesn't seem to work.  It seems to require some modification to make it work. 
It's tested in pytorch:22.07-py3 NGC container.
1. `torch.onnx.export` doesn't work with the argument `training=false`. As you know, this function works by default as an inference mode. 
2. Some unexpected arguments are being used for some class and tuple, which cause errors. They're annotated.
3. Converting from ONNX to TRT for GPT2 doesn't work due to slice ops. Polygraphy sanitizing process is added in order to make it work.
