### PR TITLE
fixed requirements.txt to use trt-engine-explorer

### DIFF
--- a/tools/experimental/trt-engine-explorer/requirements.txt
+++ b/tools/experimental/trt-engine-explorer/requirements.txt
@@ -10,10 +10,11 @@ graphviz
 jupyter
 netron
 openpyxl # for excel reporting
-ipywidgets
+ipywidgets==7.7.2
 ipyfilechooser
 jupyterlab
 jupyter-dash
 pytest
 dtale==2.2.0
 xlsxwriter
+Flask==2.0.0


### PR DESCRIPTION
I tried to use trt-engine-explorer and [this notebook](https://github.com/NVIDIA/TensorRT/tree/8.5.1/tools/experimental/trt-engine-explorer/notebooks) with TensorRT v8.5.1.
But, the version of the following package is incompatible.

- ipywidgets
- Flask

So, I fixed requirements.txt. And, I checked on the following environments.

- Ubuntu 20.04, Python 3.8
- Ubuntu 22.04, Python 3.10