### PR TITLE
Fix np.unicode deprecation

### DIFF
--- a/tools/Polygraphy/polygraphy/backend/onnxrt/runner.py
+++ b/tools/Polygraphy/polygraphy/backend/onnxrt/runner.py
@@ -56,7 +56,7 @@ class OnnxrtRunner(BaseRunner):
             "tensor(uint64)": np.uint64,
             "tensor(uint8)": np.uint8,
             "tensor(bool)": bool,
-            "tensor(string)": np.unicode,
+            "tensor(string)": str,
         }
 
         meta = TensorMetadata()


### PR DESCRIPTION
```
Python 3.9.15 (main, Nov  4 2022, 16:35:55) [MSC v.1916 64 bit (AMD64)] :: Anaconda, Inc. on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> np.unicode
<stdin>:1: DeprecationWarning: `np.unicode` is a deprecated alias for `np.compat.unicode`. To silence this warning, use `np.compat.unicode` by itself. In the likely event your code does not need to work on Python 2 you can use the builtin `str` for which `np.compat.unicode` is itself an alias. Doing this will not modify any behaviour and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
<class 'str'>
>>> np.__version__
'1.23.5'
```

On numpy 1.24 np.unicode is removed and polygraphy with ORT crashes.