### PR TITLE
Fix NvInferRuntime.h

### DIFF
--- a/include/NvInferRuntime.h
+++ b/include/NvInferRuntime.h
@@ -47,7 +47,7 @@ class INoCopy
 {
 protected:
     INoCopy() = default;
-    virtual ~INoCopy() = default;
+    ~INoCopy() = default;
     INoCopy(const INoCopy& other) = delete;
     INoCopy& operator=(const INoCopy& other) = delete;
     INoCopy(INoCopy&& other) = delete;


### PR DESCRIPTION
"A base class destructor should be either public and virtual, or protected and non-virtual". 
There are very few use cases when the destructor has to be protected and virtual. But I don't think the one here belongs to those use cases.