### PR TITLE
polygraphy: Misc fixes for pytorch runner

### DIFF
--- a/tools/Polygraphy/polygraphy/backend/pyt/runner.py
+++ b/tools/Polygraphy/polygraphy/backend/pyt/runner.py
@@ -68,8 +68,9 @@ class PytRunner(BaseRunner):
 
         out_dict = OrderedDict()
         for name, output in zip(self.output_names, outputs):
-            out_dict[name] = output.cpu().numpy()
-        return out_dict, end - start
+            out_dict[name] = output.detach().cpu().numpy()
+        self.inference_time = end - start
+        return out_dict
 
     def deactivate_impl(self):
         del self.model


### PR DESCRIPTION
Fixes:

```
Fix [W] pytorch-runner-N0-04/26/23-22:50:28 | `inference_time` was not set. Inference time will be incorrect! To correctly compare runtimes, please set the `inference_time` attribute in `infer_impl()`
```

Also fixes `RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.`