### PR TITLE
Onnx GraphSurgeon update graph to fold identity constant

### DIFF
--- a/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py
+++ b/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py
@@ -944,6 +944,13 @@ class Graph(object):
             graph_tensors = self.tensors()
             for name, values in constant_values.items():
                 tensor = graph_tensors[name]
+
+                for node in tensor.outputs:
+                    if node.op == "Identity":
+                        t = node.outputs[0]
+                        t.to_constant(tensor._values)  # Using ._values avoids copying
+                        t.inputs.clear() # Constants do not need inputs
+                
                 if isinstance(tensor, Constant):
                     # No need to fold tensors that are already constant.
                     continue


### PR DESCRIPTION
Hi, for pytorch 2.0, by using torch.onnx.export, constant with same value and shape will be shared and creates many identity nodes, these nodes should and can be folded. This pr fix this.

![image](https://github.com/NVIDIA/TensorRT/assets/46103969/dea021a3-ce96-4342-afa8-f75128387345)

model link      
[resnet18.onnx](http://120.224.26.73:15030/aifarm/tmp/test_torchvision[resnet18].onnx)