### PR TITLE
Fix sdist installation

### DIFF
--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -96,9 +96,9 @@ To install, please execute the following:
 ```
 pip install tensorrt --extra-index-url {nvidia_pip_index_url}
 ```
-Or put the index URL in the (comma-separated) PIP_EXTRA_INDEX_URL environment variable:
+Or add the index URL to the (space-separated) PIP_EXTRA_INDEX_URL environment variable:
 ```
-export PIP_EXTRA_INDEX_URL={nvidia_pip_index_url}
+export PIP_EXTRA_INDEX_URL='{nvidia_pip_index_url}'
 pip install tensorrt
 ```
 When the extra index url does not contain `{nvidia_pip_index_url}`, a nested `pip install` will run with the proper extra index url hard-coded.

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -14,30 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import platform
+import sys
 
 from setuptools import setup
 
 tensorrt_module = "##TENSORRT_MODULE##"
 tensorrt_version = "##TENSORRT_PYTHON_VERSION##"
+index_url = "https://pypi.nvidia.com"
 
+# cherry-pick information from `packaging.markers.default_environment()` needed to find the right wheel
+# https://github.com/pypa/packaging/blob/23.1/src/packaging/markers.py#L175-L190
+if sys.platform == "linux":
+    platform_marker = "manylinux_2_17"
+else:
+    raise RuntimeError("TensorRT currently only builds wheels for linux")
+
+if sys.implementation.name == "cpython":
+    implementation_marker = "cp{}".format("".join(platform.python_version_tuple()[:2]))
+else:
+    raise RuntimeError("TensorRT currently only builds wheels for CPython")
+
+machine_marker = platform.machine()
+if machine_marker != "x86_64":
+    raise RuntimeError("TensorRT currently only builds wheels for x86_64 processors")
+
+libs_wheel = "{}/{}-libs/{}_libs-{}-py2.py3-none-{}_{}.whl".format(
+    index_url,
+    tensorrt_module,
+    tensorrt_module,
+    tensorrt_version,
+    platform_marker,
+    machine_marker,
+)
+bindings_wheel = "{}/{}-bindings/{}_bindings-{}-{}-none-{}_{}.whl".format(
+    index_url,
+    tensorrt_module,
+    tensorrt_module,
+    tensorrt_version,
+    implementation_marker,
+    platform_marker,
+    machine_marker,
+)
 
 setup(
     name=tensorrt_module,
     version=tensorrt_version,
     description="A high performance deep learning inference library",
-    long_description="""A high performance deep learning inference library
-
-To install, please execute the following:
-```
-pip install tensorrt --extra-index-url https://pypi.nvidia.com
-```
-Or put the index URL in the (comma-separated) PIP_EXTRA_INDEX_URL environment variable:
-```
-export PIP_EXTRA_INDEX_URL=https://pypi.nvidia.com
-pip install tensorrt
-```
-""",
-    long_description_content_type="text/markdown",
+    long_description="A high performance deep learning inference library",
     author="NVIDIA Corporation",
     license="Proprietary",
     classifiers=[
@@ -47,9 +71,10 @@ pip install tensorrt
     ],
     packages=[tensorrt_module],
     install_requires=[
-        "{}_libs=={}".format(tensorrt_module, tensorrt_version),
-        "{}_bindings=={}".format(tensorrt_module, tensorrt_version),
+        "{}_libs @ {}".format(tensorrt_module, libs_wheel),
+        "{}_bindings @ {}".format(tensorrt_module, bindings_wheel),
     ],
+    python_requires=">=3.6",  # ref https://pypi.nvidia.com/tensorrt-bindings/
     extras_require={"numpy": "numpy"},
     package_data={tensorrt_module: ["*.so*", "*.pyd", "*.pdb"]},
     include_package_data=True,

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -29,6 +29,7 @@ tensorrt_submodules = [
     "{}_bindings=={}".format(tensorrt_module, tensorrt_version),
 ]
 nvidia_pip_index_url = os.environ.get("NVIDIA_PIP_INDEX_URL", "https://pypi.nvidia.com")
+disable_internal_pip = os.environ.get("NVIDIA_TENSORRT_DISABLE_INTERNAL_PIP", False)
 
 
 class InstallCommand(install):
@@ -79,7 +80,8 @@ def parent_command_line():
 
 # use pip-inside-pip hack only if the nvidia index is not set in the environment
 if (
-    nvidia_pip_index_url in pip_config_list()
+    disable_internal_pip
+    or nvidia_pip_index_url in pip_config_list()
     or nvidia_pip_index_url in parent_command_line()
 ):
     install_requires = tensorrt_submodules

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -28,6 +28,7 @@ tensorrt_submodules = [
     "{}_libs=={}".format(tensorrt_module, tensorrt_version),
     "{}_bindings=={}".format(tensorrt_module, tensorrt_version),
 ]
+nvidia_pip_index_url = os.environ.get("NVIDIA_PIP_INDEX_URL", "https://pypi.nvidia.com")
 
 
 class InstallCommand(install):
@@ -38,7 +39,7 @@ class InstallCommand(install):
                 "{}/bin/pip".format(sys.exec_prefix),
                 "install",
                 "--extra-index-url",
-                "https://pypi.nvidia.com",
+                nvidia_pip_index_url,
                 *tensorrt_submodules,
             ]
         )
@@ -77,7 +78,7 @@ def parent_command_line():
 
 
 # use pip-inside-pip hack only if the nvidia index is not set in the environment
-if "pypi.nvidia.com" in pip_config_list() or "pypi.nvidia.com" in parent_command_line():
+if nvidia_pip_index_url in pip_config_list() or nvidia_pip_index_url in parent_command_line():
     install_requires = tensorrt_submodules
     cmdclass = {}
 else:
@@ -89,18 +90,18 @@ setup(
     name=tensorrt_module,
     version=tensorrt_version,
     description="A high performance deep learning inference library",
-    long_description="""A high performance deep learning inference library
+    long_description=f"""A high performance deep learning inference library
 
 To install, please execute the following:
 ```
-pip install tensorrt --extra-index-url https://pypi.nvidia.com
+pip install tensorrt --extra-index-url {nvidia_pip_index_url}
 ```
 Or put the index URL in the (comma-separated) PIP_EXTRA_INDEX_URL environment variable:
 ```
-export PIP_EXTRA_INDEX_URL=https://pypi.nvidia.com
+export PIP_EXTRA_INDEX_URL={nvidia_pip_index_url}
 pip install tensorrt
 ```
-When the extra index url does not contain `pypi.nvidia.com`, a nested `pip install` will run with the proper extra index url hard-coded.
+When the extra index url does not contain `{nvidia_pip_index_url}`, a nested `pip install` will run with the proper extra index url hard-coded.
 """,
     long_description_content_type="text/markdown",
     author="NVIDIA Corporation",

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -14,54 +14,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import platform
-import sys
 
 from setuptools import setup
 
 tensorrt_module = "##TENSORRT_MODULE##"
 tensorrt_version = "##TENSORRT_PYTHON_VERSION##"
-index_url = "https://pypi.nvidia.com"
 
-# cherry-pick information from `packaging.markers.default_environment()` needed to find the right wheel
-# https://github.com/pypa/packaging/blob/23.1/src/packaging/markers.py#L175-L190
-if sys.platform == "linux":
-    platform_marker = "manylinux_2_17"
-else:
-    raise RuntimeError("TensorRT currently only builds wheels for linux")
-
-if sys.implementation.name == "cpython":
-    implementation_marker = "cp{}".format("".join(platform.python_version_tuple()[:2]))
-else:
-    raise RuntimeError("TensorRT currently only builds wheels for CPython")
-
-machine_marker = platform.machine()
-if machine_marker != "x86_64":
-    raise RuntimeError("TensorRT currently only builds wheels for x86_64 processors")
-
-libs_wheel = "{}/{}-libs/{}_libs-{}-py2.py3-none-{}_{}.whl".format(
-    index_url,
-    tensorrt_module,
-    tensorrt_module,
-    tensorrt_version,
-    platform_marker,
-    machine_marker,
-)
-bindings_wheel = "{}/{}-bindings/{}_bindings-{}-{}-none-{}_{}.whl".format(
-    index_url,
-    tensorrt_module,
-    tensorrt_module,
-    tensorrt_version,
-    implementation_marker,
-    platform_marker,
-    machine_marker,
-)
 
 setup(
     name=tensorrt_module,
     version=tensorrt_version,
     description="A high performance deep learning inference library",
-    long_description="A high performance deep learning inference library",
+    long_description="""A high performance deep learning inference library
+
+To install, please execute the following:
+```
+pip install tensorrt --extra-index-url https://pypi.nvidia.com
+```
+Or put the index URL in the (comma-separated) PIP_EXTRA_INDEX_URL environment variable:
+```
+export PIP_EXTRA_INDEX_URL=https://pypi.nvidia.com
+pip install tensorrt
+```
+""",
+    long_description_content_type="text/markdown",
     author="NVIDIA Corporation",
     license="Proprietary",
     classifiers=[
@@ -71,10 +47,9 @@ setup(
     ],
     packages=[tensorrt_module],
     install_requires=[
-        "{}_libs @ {}".format(tensorrt_module, libs_wheel),
-        "{}_bindings @ {}".format(tensorrt_module, bindings_wheel),
+        "{}_libs=={}".format(tensorrt_module, tensorrt_version),
+        "{}_bindings=={}".format(tensorrt_module, tensorrt_version),
     ],
-    python_requires=">=3.6",  # ref https://pypi.nvidia.com/tensorrt-bindings/
     extras_require={"numpy": "numpy"},
     package_data={tensorrt_module: ["*.so*", "*.pyd", "*.pdb"]},
     include_package_data=True,

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -69,11 +69,9 @@ def parent_command_line():
         pass
     # fall back to shell
     try:
-        return (
-            subprocess.check_output(["ps", "-p", str(pid), "-o", "command"])
-            .decode()
-            .split("\n")[1]
-        )
+        return subprocess.check_output(
+            ["ps", "-p", str(pid), "-o", "command", "--no-headers"]
+        ).decode()
     except subprocess.CalledProcessError:
         return ""
 

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -78,7 +78,10 @@ def parent_command_line():
 
 
 # use pip-inside-pip hack only if the nvidia index is not set in the environment
-if nvidia_pip_index_url in pip_config_list() or nvidia_pip_index_url in parent_command_line():
+if (
+    nvidia_pip_index_url in pip_config_list()
+    or nvidia_pip_index_url in parent_command_line()
+):
     install_requires = tensorrt_submodules
     cmdclass = {}
 else:

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -93,19 +93,21 @@ setup(
     name=tensorrt_module,
     version=tensorrt_version,
     description="A high performance deep learning inference library",
-    long_description=f"""A high performance deep learning inference library
+    long_description="""A high performance deep learning inference library
 
 To install, please execute the following:
 ```
-pip install tensorrt --extra-index-url {nvidia_pip_index_url}
+pip install tensorrt --extra-index-url {}
 ```
 Or add the index URL to the (space-separated) PIP_EXTRA_INDEX_URL environment variable:
 ```
-export PIP_EXTRA_INDEX_URL='{nvidia_pip_index_url}'
+export PIP_EXTRA_INDEX_URL='{}'
 pip install tensorrt
 ```
-When the extra index url does not contain `{nvidia_pip_index_url}`, a nested `pip install` will run with the proper extra index url hard-coded.
-""",
+When the extra index url does not contain `{}`, a nested `pip install` will run with the proper extra index url hard-coded.
+""".format(
+        nvidia_pip_index_url, nvidia_pip_index_url, nvidia_pip_index_url
+    ),
     long_description_content_type="text/markdown",
     author="NVIDIA Corporation",
     license="Proprietary",
@@ -116,6 +118,7 @@ When the extra index url does not contain `{nvidia_pip_index_url}`, a nested `pi
     ],
     packages=[tensorrt_module],
     install_requires=install_requires,
+    python_requires=">=3.6",  # ref https://pypi.nvidia.com/tensorrt-bindings/
     cmdclass=cmdclass,
     extras_require={"numpy": "numpy"},
     package_data={tensorrt_module: ["*.so*", "*.pyd", "*.pdb"]},

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -25,7 +25,18 @@ setup(
     name=tensorrt_module,
     version=tensorrt_version,
     description="A high performance deep learning inference library",
-    long_description="A high performance deep learning inference library\n\nInstall using `pip install tensorrt --extra-index-url https://pypi.nvidia.com` or run `export PIP_EXTRA_INDEX_URL=https://pypi.nvidia.com` (comma-separated URLs) and then `pip install tensorrt`.",
+    long_description="""A high performance deep learning inference library
+
+To install, please execute the following:
+```
+pip install tensorrt --extra-index-url https://pypi.nvidia.com
+```
+Or put the index URL in the (comma-separated) PIP_EXTRA_INDEX_URL environment variable:
+```
+export PIP_EXTRA_INDEX_URL=https://pypi.nvidia.com
+pip install tensorrt
+```
+""",
     long_description_content_type="text/markdown",
     author="NVIDIA Corporation",
     license="Proprietary",

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -15,42 +15,18 @@
 # limitations under the License.
 #
 
-import sys
-
 from setuptools import setup
-from setuptools.command.install import install
-import subprocess as sp
 
 tensorrt_module = "##TENSORRT_MODULE##"
-
-
-class InstallCommand(install):
-    def run(self):
-        def install_dep(package_name):
-            status = sp.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "pip",
-                    "install",
-                    "{:}==##TENSORRT_PYTHON_VERSION##".format(package_name),
-                    "--index-url",
-                    "https://pypi.nvidia.com",
-                ]
-            )
-            status.check_returncode()
-
-        install_dep("{:}_libs".format(tensorrt_module))
-        install_dep("{:}_bindings".format(tensorrt_module))
-
-        install.run(self)
+tensorrt_version = "##TENSORRT_PYTHON_VERSION##"
 
 
 setup(
     name=tensorrt_module,
-    version="##TENSORRT_PYTHON_VERSION##",
+    version=tensorrt_version,
     description="A high performance deep learning inference library",
-    long_description="A high performance deep learning inference library",
+    long_description="A high performance deep learning inference library\n\nInstall using `pip install tensorrt --extra-index-url https://pypi.nvidia.com` or run `export PIP_EXTRA_INDEX_URL=https://pypi.nvidia.com` (comma-separated URLs) and then `pip install tensorrt`.",
+    long_description_content_type="text/markdown",
     author="NVIDIA Corporation",
     license="Proprietary",
     classifiers=[
@@ -59,6 +35,10 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     packages=[tensorrt_module],
+    install_requires=[
+        "{}_libs=={}".format(tensorrt_module, tensorrt_version),
+        "{}_bindings=={}".format(tensorrt_module, tensorrt_version),
+    ],
     extras_require={"numpy": "numpy"},
     package_data={tensorrt_module: ["*.so*", "*.pyd", "*.pdb"]},
     include_package_data=True,
@@ -66,5 +46,4 @@ setup(
     keywords="nvidia tensorrt deeplearning inference",
     url="https://developer.nvidia.com/tensorrt",
     download_url="https://github.com/nvidia/tensorrt/tags",
-    cmdclass={"install": InstallCommand},
 )

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -46,6 +46,17 @@ class InstallCommand(install):
         super().run()
 
 
+def pip_config_list():
+    """Get the current pip config (env vars, config file, etc)."""
+    return subprocess.check_output(
+        [
+            "{}/bin/pip".format(sys.exec_prefix),
+            "config",
+            "list",
+        ]
+    ).decode()
+
+
 def parent_command_line():
     """Get the command line of the parent PID."""
     pid = os.getppid()
@@ -68,10 +79,7 @@ def parent_command_line():
 
 
 # use pip-inside-pip hack only if the nvidia index is not set in the environment
-if (
-    "pypi.nvidia.com" in os.environ.get("PIP_EXTRA_INDEX_URL", "")
-    or "pypi.nvidia.com" in parent_command_line()
-):
+if "pypi.nvidia.com" in pip_config_list() or "pypi.nvidia.com" in parent_command_line():
     install_requires = tensorrt_submodules
     cmdclass = {}
 else:

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -102,7 +102,7 @@ Or put the index URL in the (comma-separated) PIP_EXTRA_INDEX_URL environment va
 export PIP_EXTRA_INDEX_URL=https://pypi.nvidia.com
 pip install tensorrt
 ```
-When the extra index url is not found, a nested `pip install` will run with the extra index url hard-coded.
+When the extra index url does not contain `pypi.nvidia.com`, a nested `pip install` will run with the proper extra index url hard-coded.
 """,
     long_description_content_type="text/markdown",
     author="NVIDIA Corporation",


### PR DESCRIPTION
Fixes #3078

This PR ~removes~ amends the 'pip inside pip' anti-pattern and updates the PyPI description:

> To install, please execute the following:
> ```
> pip install tensorrt --extra-index-url https://pypi.nvidia.com
> ```
> Or add the index URL to the (space-separated) PIP_EXTRA_INDEX_URL environment variable:
> ```
> export PIP_EXTRA_INDEX_URL='https://pypi.nvidia.com'
> pip install tensorrt
> ```
> When the extra index url does not contain `https://pypi.nvidia.com`, a nested `pip install` will run with the proper extra index url hard-coded.

I tried to find the source code of ERROR.txt inside `tensorrt_libs` sdist on official PyPI (so I could update the message with the `PIP_EXTRA_INDEX_URL` env var), but couldn't find it. Can you update that error message accordingly? Similarly this one will also need an update: https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html