### PR TITLE
Add platform checks before nested pip call

### DIFF
--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -39,20 +39,13 @@ def run_pip_command(args, call_func):
     except subprocess.CalledProcessError:
         return call_func([os.path.join(sys.exec_prefix, "bin", "pip")] + args)
 
-# cherry-pick information from `packaging.markers.default_environment()` needed to find the right wheel
-# https://github.com/pypa/packaging/blob/23.1/src/packaging/markers.py#L175-L190
-if sys.platform == "linux":
-    platform_marker = "manylinux_2_17"
-else:
+
+# check wheel availability using information from https://github.com/pypa/packaging/blob/23.1/src/packaging/markers.py#L175-L190
+if sys.platform != "linux":
     raise RuntimeError("TensorRT currently only builds wheels for linux")
-
-if sys.implementation.name == "cpython":
-    implementation_marker = "cp{}".format("".join(platform.python_version_tuple()[:2]))
-else:
+if sys.implementation.name != "cpython":
     raise RuntimeError("TensorRT currently only builds wheels for CPython")
-
-machine_marker = platform.machine()
-if machine_marker != "x86_64":
+if platform.machine() != "x86_64":
     raise RuntimeError("TensorRT currently only builds wheels for x86_64 processors")
 
 

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -41,11 +41,11 @@ def run_pip_command(args, call_func):
 
 
 # check wheel availability using information from https://github.com/pypa/packaging/blob/23.1/src/packaging/markers.py#L175-L190
-if sys.platform != "linux":
-    raise RuntimeError("TensorRT currently only builds wheels for linux")
+if sys.platform not in ("linux", "win32"):
+    raise RuntimeError("TensorRT currently only builds wheels for Linux and Windows")
 if sys.implementation.name != "cpython":
     raise RuntimeError("TensorRT currently only builds wheels for CPython")
-if platform.machine() != "x86_64":
+if platform.machine() not in ("x86_64", "AMD64"):
     raise RuntimeError("TensorRT currently only builds wheels for x86_64 processors")
 
 

--- a/python/packaging/frontend_sdist/setup.py
+++ b/python/packaging/frontend_sdist/setup.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import platform
 import sys
 
 from setuptools import setup
@@ -22,6 +23,22 @@ from setuptools.command.install import install
 import subprocess as sp
 
 tensorrt_module = "##TENSORRT_MODULE##"
+
+# cherry-pick information from `packaging.markers.default_environment()` needed to find the right wheel
+# https://github.com/pypa/packaging/blob/23.1/src/packaging/markers.py#L175-L190
+if sys.platform == "linux":
+    platform_marker = "manylinux_2_17"
+else:
+    raise RuntimeError("TensorRT currently only builds wheels for linux")
+
+if sys.implementation.name == "cpython":
+    implementation_marker = "cp{}".format("".join(platform.python_version_tuple()[:2]))
+else:
+    raise RuntimeError("TensorRT currently only builds wheels for CPython")
+
+machine_marker = platform.machine()
+if machine_marker != "x86_64":
+    raise RuntimeError("TensorRT currently only builds wheels for x86_64 processors")
 
 
 class InstallCommand(install):


### PR DESCRIPTION
More verbose errors for #2933 

based on https://github.com/NVIDIA/TensorRT/pull/3080/commits/5334f0dc8b970fd6ec51f75f8fd93c156943d219