### PR TITLE
[onnx-graphsurgeon] Add ir_version to Graph

### DIFF
--- a/tools/onnx-graphsurgeon/onnx_graphsurgeon/exporters/onnx_exporter.py
+++ b/tools/onnx-graphsurgeon/onnx_graphsurgeon/exporters/onnx_exporter.py
@@ -149,6 +149,7 @@ def export_onnx(graph: Graph, do_type_check=True, **kwargs) -> "onnx.ModelProto"
             kwargs["opset_imports"] = graph.import_domains
 
     model = onnx.helper.make_model(onnx_graph, **kwargs)
+    model.ir_version = graph.ir_version
     model.producer_name = graph.producer_name
     model.producer_version = graph.producer_version
     return model

--- a/tools/onnx-graphsurgeon/onnx_graphsurgeon/importers/onnx_importer.py
+++ b/tools/onnx-graphsurgeon/onnx_graphsurgeon/importers/onnx_importer.py
@@ -90,6 +90,10 @@ class OnnxImporter(BaseImporter):
         return model.opset_import
 
     @staticmethod
+    def get_ir_version(model: onnx.ModelProto):
+        return model.ir_version
+
+    @staticmethod
     def import_tensor(onnx_tensor: Union[onnx.ValueInfoProto, onnx.TensorProto]) -> Tensor:
         if isinstance(onnx_tensor, onnx.TensorProto):
             data_location = int(onnx_tensor.data_location) if onnx_tensor.HasField("data_location") else None
@@ -198,6 +202,7 @@ class OnnxImporter(BaseImporter):
         onnx_graph: onnx.GraphProto,
         tensor_map: "OrderedDict[str, Tensor]" = None,
         opset=None,
+        ir_version=None,
         import_domains: onnx.OperatorSetIdProto = None,
         producer_name: str = None,
         producer_version: str = None,
@@ -284,6 +289,7 @@ class OnnxImporter(BaseImporter):
             producer_name=producer_name,
             producer_version=producer_version,
             opset=opset,
+            ir_version=ir_version,
             import_domains=import_domains,
         )
 
@@ -301,6 +307,7 @@ def import_onnx(onnx_model: "onnx.ModelProto") -> Graph:
     return OnnxImporter.import_graph(
         onnx_model.graph,
         opset=OnnxImporter.get_opset(onnx_model),
+        ir_version=OnnxImporter.get_ir_version(onnx_model),
         import_domains=OnnxImporter.get_import_domains(onnx_model),
         producer_name=onnx_model.producer_name,
         producer_version=onnx_model.producer_version,

--- a/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py
+++ b/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py
@@ -48,6 +48,7 @@ class Graph(object):
     """
 
     DEFAULT_OPSET = 11
+    DEFAULT_IR_VERSION = 8
     OPSET_FUNC_MAP = defaultdict(dict)  # Ops registered for specific opsets.
     GLOBAL_FUNC_MAP = dict()  # Ops registered for ALL opsets.
 
@@ -100,6 +101,7 @@ class Graph(object):
         name=None,
         doc_string=None,
         opset=None,
+        ir_version=None,
         import_domains=None,
         producer_name: str = None,
         producer_version: str = None,
@@ -126,6 +128,7 @@ class Graph(object):
         self.opset = misc.default_value(opset, Graph.DEFAULT_OPSET)
         self.producer_name = misc.default_value(producer_name, "")
         self.producer_version = misc.default_value(producer_version, "")
+        self.ir_version = misc.default_value(ir_version, Graph.DEFAULT_IR_VERSION)
         self.import_domains = import_domains
         # Printing graphs can be very expensive
         G_LOGGER.ultra_verbose(lambda: "Created Graph: {:}".format(self))
@@ -1144,6 +1147,7 @@ class Graph(object):
             name=copy.copy(self.name),
             doc_string=copy.copy(self.doc_string),
             opset=copy.copy(self.opset),
+            ir_version=self.ir_version,
             import_domains=self.import_domains,
         )
 


### PR DESCRIPTION
The exported ONNX model will use the default [`ir_version`](https://github.com/onnx/onnx/blob/main/docs/Versioning.md#ir-versioning) of the current ONNX version if we don't add the `ir_version` property, which may be inconsistent with the original `ir_version` and cause some problems in downstream usage.

BTW, I noticed that the default opset version used now is 11, currently 11 looks a bit old, should we bump up the default value here

https://github.com/NVIDIA/TensorRT/blob/a167852705d74bcc619d8fad0af4b9e4d84472fc/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py#L50