### PR TITLE
fixed requirements.txt to use trt-engine-explorer

### DIFF
--- a/tools/experimental/trt-engine-explorer/requirements.txt
+++ b/tools/experimental/trt-engine-explorer/requirements.txt
@@ -12,9 +12,14 @@ netron
 openpyxl # for excel reporting
 ipywidgets==7.7.2
 ipyfilechooser
-jupyterlab
+jupyterlab==3.6.5
 jupyter-dash
 pytest
-dtale==2.2.0
+dtale==3.3.0
 xlsxwriter
 Flask==2.0.0
+Werkzeug==2.2.3
+xarray==2022.3.0
+notebook==6.1.5
+requests==2.28
+scikit-learn==1.3.0


### PR DESCRIPTION
I tried to use trt-engine-explorer and [this notebook](https://github.com/NVIDIA/TensorRT/tree/v8.6.1/tools/experimental/trt-engine-explorer/notebooks) with TensorRT v8.6.1.
But, the version of the some package is incompatible.

So, I fixed requirements.txt. And, I checked on the following environments.

- Ubuntu 20.04, Python 3.8
- Ubuntu 22.04, Python 3.10