### PR TITLE
Fix matcher bug with blossom-ci

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -34,7 +34,7 @@ jobs:
       
     # This job only runs for pull request comments
     if: |
-         contains( 'rajeevsrao,kevinch-nv,ttyio,samurdhikaru,zerollzeng,nvpohanh', format('{0},', github.actor)) && 
+         contains(FromJSON('["rajeevsrao", "kevinch-nv", "ttyio", "samurdhikaru", "zerollzeng", "nvpohanh"]'), github.actor) && 
          github.event.comment.body == '/blossom-ci'  
     steps:
       - name: Check if comment is issued by authorized person


### PR DESCRIPTION
It is possible to bypass the first check for users approved to run the blossom CI by creating a username that is a partial match. Per GitHub documentation, if the search param in contains is a string, it returns true upon a partial match. https://docs.github.com/en/actions/learn-github-actions/expressions#contains

See https://github.com/NVIDIA/TensorRT/pull/3063 for an example where I used an account that partially matched @samurdhikaru 's name.

The resulting workflow failed at the next check, so there isn't security impact (and why I am making a PR instead of disclosing privately). Updating the check to use an array will prevent someone from bypassing the actor check in this manner.