### PR TITLE
onnx_graphsurgeon: fix Sequence Tensor bug

### DIFF
--- a/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py
+++ b/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py
@@ -948,15 +948,20 @@ class Graph(object):
                     # No need to fold tensors that are already constant.
                     continue
 
-                if size_threshold is not None and values.nbytes > size_threshold:
+                if isinstance(values, list):
+                    nbytes = sum([v.nbytes for v in values])
+                else:
+                    nbytes = values.nbytes
+
+                if size_threshold is not None and nbytes > size_threshold:
                     G_LOGGER.debug(
                         "Will not fold: '{:}' since its size in bytes ({:}) exceeds the size threshold ({:})".format(
-                            name, values.nbytes, size_threshold
+                            name, nbytes, size_threshold
                         )
                     )
                     continue
-                elif size_threshold is None and values.nbytes > (1 << 20):
-                    large_tensors[name] = values.nbytes
+                elif size_threshold is None and nbytes > (1 << 20):
+                    large_tensors[name] = nbytes
 
                 tensor.to_constant(values)
                 tensor.inputs.clear()  # Constants do not need inputs

--- a/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/tensor.py
+++ b/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/tensor.py
@@ -183,7 +183,7 @@ class Variable(Tensor):
 
         Note: Generally, you should only ever make a copy of a Graph.
         """
-        return Variable(self.name, self.dtype, self.shape)
+        return Variable(self.name, self.dtype, self.shape, self.type)
 
 
 class LazyValues(object):


### PR DESCRIPTION
Hi, when using graphsurgeon to handle model with [SequenceConstruct](https://onnx.ai/onnx/operators/onnx__SequenceConstruct.html) operator, constant folding will raise an error, this pr helps fix it, model is provided [model.zip](https://github.com/NVIDIA/TensorRT/files/14035970/model.zip).

current output after constant folding looks like this:
![image](https://github.com/NVIDIA/TensorRT/assets/46103969/5f423e1e-749c-42ee-9b94-3b41d8b72721)


expected output should look like this:
![image](https://github.com/NVIDIA/TensorRT/assets/46103969/08b124fb-4dad-4e9f-a3c8-7c6c748e8f86)

