### PR TITLE
[Plugin] Fix bug of memcpy in scatter plugin

### DIFF
--- a/plugin/scatterPlugin/scatterLayer.cu
+++ b/plugin/scatterPlugin/scatterLayer.cu
@@ -85,9 +85,9 @@ pluginStatus_t scatterNDInference(
     int* wo = (int*)(workspace);
     int* transformedIdx = wo + sizeof(int)*nOutputDims;
     int* deviceTransformCoeff = wo;
-    CSC(cudaMemcpy(workspace, transformCoeff, sizeof(int) * nOutputDims, cudaMemcpyHostToDevice), STATUS_FAILURE);
+    CSC(cudaMemcpyAsync(workspace, transformCoeff, sizeof(int) * nOutputDims, cudaMemcpyHostToDevice, stream), STATUS_FAILURE);
     transformIdxKernel<<<nRows, 1, 0, stream>>>(transformedIdx, deviceTransformCoeff, _index, sliceRank);
-    CSC(cudaMemcpy(output, data, copySize, cudaMemcpyDeviceToDevice), STATUS_FAILURE);
+    CSC(cudaMemcpyAsync(output, data, copySize, cudaMemcpyDeviceToDevice, stream), STATUS_FAILURE);
     // assuming output pitch = rowSize i.e no padding
     scatterKernel<<<nRows, 1, 0, stream>>>(_output, _updates, transformedIdx, rowSize * 4, rowSize * 4);
     return STATUS_SUCCESS;


### PR DESCRIPTION
In the scatter plugin, `cudaMemcpy` with implicit synchronization is used to complete data copying, ensuring that `device_transform_coeff` is properly assigned before the kernel execution. However, this method fails when using `cudaStreamNonBlocking` stream for inference in TensorRT, resulting in incorrect outcomes. This issue can be resolved by switching to `cudaMemcpyAsync` and using the same stream as the kernel, yielding correct results.