### PR TITLE
onnx-graphsurgeon: fix cycle detection bug in toposort

### DIFF
--- a/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py
+++ b/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py
@@ -595,6 +595,7 @@ class Graph(object):
                 return inputs
 
             if get_id(node_or_func) in hierarchy_levels:
+                visited.remove(get_id(node_or_func))
                 return hierarchy_levels[get_id(node_or_func)].level
 
             # The level of a node is the level of its highest input + 1.


### PR DESCRIPTION
Fix issue #4086 

With this modification. Run toposort on model in #4086 return successfully with:
```python
import onnx
import onnx_graphsurgeon as gs

graph = gs.import_onnx(onnx.load('./toposort.onnx'))
graph.toposort()
""" Out:
Graph onnx_graphsurgeon_graph (Opset 11)
Local Functions: []
Inputs: [Variable (input): (shape=[], dtype=float32)]
Nodes: identity_0 (Identity)
        Inputs: [
                Variable (input): (shape=[], dtype=float32)
        ]
        Outputs: [
                Variable (identity_0_output): (shape=[], dtype=float32)
        ]
neg_1 (Neg)
        Inputs: [
                Variable (identity_0_output): (shape=[], dtype=float32)
        ]
        Outputs: [
                Variable (neg_1_output): (shape=[], dtype=float32)
        ]
mul_0 (Mul)
        Inputs: [
                Variable (identity_0_output): (shape=[], dtype=float32)
                Variable (neg_1_output): (shape=[], dtype=float32)
        ]
        Outputs: [
                Variable (mul_0_output): (shape=[], dtype=float32)
        ]
Outputs: [Variable (mul_0_output): (shape=[], dtype=float32)]
"""
```