### PR TITLE
Support provide ORT session options in onnx_graphsurgeon fold_constants

### DIFF
--- a/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py
+++ b/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py
@@ -703,6 +703,7 @@ class Graph(object):
         size_threshold=None,
         should_exclude_node=None,
         recurse_functions=True,
+        ort_session_options=None,
     ):
         """
         Folds constants in-place in the graph. The graph's nodes and functions must be topologically
@@ -758,7 +759,8 @@ class Graph(object):
             recurse_functions (bool):
                     Whether to fold constants in this graph's Functions.
                     Defaults to True.
-
+            ort_session_options (Optional[onnxruntime.SessionOptions]):
+                    SessionOptions object to be used for ONNX Runtime sessions.
         Returns:
             self
         """
@@ -1176,6 +1178,7 @@ class Graph(object):
 
                     sess = onnxrt.InferenceSession(
                         export_onnx(part, do_type_check=False).SerializeToString(),
+                        sess_options = ort_session_options,
                         providers=ORT_PROVIDERS,
                     )
                     values = sess.run(names, {})
@@ -1258,6 +1261,7 @@ class Graph(object):
                         export_onnx(
                             graph_clone, do_type_check=False
                         ).SerializeToString(),
+                        sess_options = ort_session_options,
                         providers=ORT_PROVIDERS,
                     )
                     values = sess.run(names, {})


### PR DESCRIPTION
Closes #4574

> User can provide the custom operator libs by

```
so = ort.SessionOptions()
so.register_custom_ops_library(...)
g.fold_constants(..., ort_session_options=so)
```

> Passing some options to avoid some ORT bug

```
so = ort.SessionOptions()
so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
g.fold_constants(..., ort_session_options=so)
```