### PR TITLE
Use correct cuda runtime dependency for CUDA 13

### DIFF
--- a/python/packaging/libs_wheel/setup.py
+++ b/python/packaging/libs_wheel/setup.py
@@ -23,7 +23,10 @@ import_package_name = "##TENSORRT_MODULE##_libs"
 
 
 def get_requirements():
-    reqs = ["nvidia-cuda-runtime-cu##CUDA_MAJOR##"]
+    if "##CUDA_MAJOR##" == "13":
+        reqs = ["nvidia-cuda-runtime"]
+    else:
+        reqs = ["nvidia-cuda-runtime-cu##CUDA_MAJOR##"]
     return reqs
 
 


### PR DESCRIPTION
When building the libs-wheel package for CUDA 13, the script
was installing nvidia-cuda-runtime-cu13, which has been deprecated on
Oct 31 2025, making it impossible to install the package on CUDA 13.

This commit fixes the issue by installing nvidia-cuda-runtime instead. nvidia-cuda-runtime-cu12 and cu11 have not been deprecated,
so they are still being used when CUDA major is 12 or 11, to maintain existing behaviour.

Solves https://github.com/NVIDIA/TensorRT/issues/4614
