### PR TITLE
Fix runtime error in detectron2 sample due to wrong variable usage

### DIFF
--- a/samples/python/detectron2/infer.py
+++ b/samples/python/detectron2/infer.py
@@ -120,7 +120,7 @@ class TensorRTInfer:
             self.inputs[0]["allocation"], np.ascontiguousarray(batch)
         )
 
-        self.context.execute_v2(self.device_memories)
+        self.context.execute_v2([d.device_ptr for d in self.device_memories])
         for o in range(len(outputs)):
             common.memcpy_device_to_host(outputs[o], self.outputs[o]["allocation"])
 


### PR DESCRIPTION
Fixed a bug in `infer.py` where `self.allocations` was passed to the execution context instead of `self.device_memories`. 