### PR TITLE
Fix runtime error in detectron2 sample due to wrong variable usage

### DIFF
--- a/samples/python/detectron2/infer.py
+++ b/samples/python/detectron2/infer.py
@@ -120,7 +120,7 @@ class TensorRTInfer:
             self.inputs[0]["allocation"], np.ascontiguousarray(batch)
         )
 
-        self.context.execute_v2(self.allocations)
+        self.context.execute_v2([d.device_ptr for d in self.device_memories])
         for o in range(len(outputs)):
             common.memcpy_device_to_host(outputs[o], self.outputs[o]["allocation"])
 


### PR DESCRIPTION
Replaced the outdated `self.allocations` with `[d.device_ptr for d in self.device_memories]` in the inference loop. This fixes the execution failure caused by passing incorrect variable.