### PR TITLE
Revert ONNX version upgrade in Graphsurgeon "Merge pull request #4653 from m-gupta/main"

### DIFF
--- a/tools/onnx-graphsurgeon/onnx_graphsurgeon/exporters/onnx_exporter.py
+++ b/tools/onnx-graphsurgeon/onnx_graphsurgeon/exporters/onnx_exporter.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from typing import List, Sequence, Union
 
-import ml_dtypes
 import numpy as np
 import onnx
 import onnx.numpy_helper
@@ -132,12 +131,12 @@ class NumpyArrayConverter(object):
 
 _NUMPY_ARRAY_CONVERTERS = {
     onnx.TensorProto.BFLOAT16: NumpyArrayConverter(
-        np.uint16, ml_dtypes.bfloat16
+        np.uint16, onnx.helper.float32_to_bfloat16
     ),
     # FP8 in TensorRT supports negative zeros, no infinities
     # See https://onnx.ai/onnx/technical/float8.html#papers
     onnx.TensorProto.FLOAT8E4M3FN: NumpyArrayConverter(
-        np.uint8, lambda x: ml_dtypes.float8_e4m3fn(x)
+        np.uint8, lambda x: onnx.helper.float32_to_float8e4m3(x, fn=True, uz=False)
     ),
 }
 

--- a/tools/onnx-graphsurgeon/setup.py
+++ b/tools/onnx-graphsurgeon/setup.py
@@ -29,7 +29,6 @@ def no_publish():
 
 
 REQUIRED_PACKAGES = [
-    "ml_dtypes",
     "numpy",
     "onnx>=1.14.0,<=1.16.1",
 ]

--- a/tools/onnx-graphsurgeon/tests/test_exporters.py
+++ b/tools/onnx-graphsurgeon/tests/test_exporters.py
@@ -214,13 +214,13 @@ class TestOnnxExporter(object):
                 onnx.TensorProto.BFLOAT16,
                 np.uint16,
                 0.02,
-                np.float32,
+                onnx.numpy_helper.bfloat16_to_float32,
             ),
             (
                 onnx.TensorProto.FLOAT8E4M3FN,
                 np.uint8,
                 0.35,
-                lambda x, dims: np.float32(x),
+                lambda x, dims: onnx.numpy_helper.float8e4m3_to_float32(x, dims, fn=True, uz=False),
             ),
         ],
     )


### PR DESCRIPTION
This reverts https://github.com/NVIDIA/TensorRT/pull/4653 due to errors. The ONNX upgrade in Graphsurgeon will be available in a future release.