### PR TITLE
fix(polygraphy): use weights_only=True in torch.load to prevent RCE

### DIFF
--- a/tools/Polygraphy/polygraphy/json/serde.py
+++ b/tools/Polygraphy/polygraphy/json/serde.py
@@ -265,7 +265,7 @@ def try_register_common_json(func):
             def decode(dct):
                 data = base64.b64decode(dct["tensor"].encode(), validate=True)
                 infile = io.BytesIO(data)
-                return torch.load(infile)
+                return torch.load(infile, weights_only=True)
 
             TORCH_REGISTRATION_SUCCESS = True
 


### PR DESCRIPTION
## Summary

- **Vulnerability**: Arbitrary Code Execution (RCE) via unsafe pickle deserialization in `polygraphy/json/serde.py`
- **Root Cause**: `torch.load(infile)` was called without `weights_only=True`, allowing maliciously crafted Polygraphy JSON files to execute arbitrary code via Python's `pickle` module
- **Fix**: Pass `weights_only=True` to `torch.load()`, restricting deserialization to tensor data only

### Change

```python
# Before (vulnerable)
return torch.load(infile)

# After (safe)
return torch.load(infile, weights_only=True)
```

## Impact

An attacker who can supply a crafted Polygraphy JSON file (e.g. via the CLI or Python API) can execute arbitrary code in the victim's process context. This enables data exfiltration, privilege escalation, and other attacks.

## Compatibility

`weights_only=True` has been supported since **PyTorch 1.13**, which is already the minimum version declared by Polygraphy (`torch>=1.13.0`). No compatibility issues expected.

## References

- NVBugs #5934574 - [PSIRT] Tensor-RT LLM pickle deserialization pytorch
- [PyTorch docs: torch.load](https://pytorch.org/docs/stable/generated/torch.load.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)