### PR TITLE
Fix Polygraphy to-input multi-iteration merge

### DIFF
--- a/tools/Polygraphy/polygraphy/tools/data/subtool/to_input.py
+++ b/tools/Polygraphy/polygraphy/tools/data/subtool/to_input.py
@@ -58,7 +58,9 @@ class ToInput(Tool):
                 )
 
             # Pad to appropriate length
-            inputs += [OrderedDict()] * (len(new_inputs) - len(inputs))
+            inputs += [
+                OrderedDict() for _ in range(len(new_inputs) - len(inputs))
+            ]
 
             for inp, new_inp in zip(inputs, new_inputs):
                 inp.update(new_inp)

--- a/tools/Polygraphy/tests/tools/test_data.py
+++ b/tools/Polygraphy/tests/tools/test_data.py
@@ -16,7 +16,7 @@
 #
 import numpy as np
 from polygraphy import util
-from polygraphy.json import load_json
+from polygraphy.json import load_json, save_json
 from tests.models.meta import ONNX_MODELS
 
 
@@ -40,3 +40,17 @@ class TestToInput:
             assert len(merged_data) == 1
             assert list(merged_data[0].keys()) == ["x", "y"]
             assert all(isinstance(val, np.ndarray) for val in merged_data[0].values())
+
+    def test_preserves_multi_iteration_inputs(self, poly_data):
+        iter0 = {"x": np.array([0], dtype=np.float32)}
+        iter1 = {"x": np.array([1], dtype=np.float32)}
+
+        with util.NamedTemporaryFile() as inps, util.NamedTemporaryFile() as merged:
+            save_json([iter0, iter1], inps.name)
+
+            poly_data(["to-input", inps.name, "-o", merged.name])
+
+            merged_data = load_json(merged.name)
+            assert len(merged_data) == 2
+            assert np.array_equal(merged_data[0]["x"], iter0["x"])
+            assert np.array_equal(merged_data[1]["x"], iter1["x"])


### PR DESCRIPTION
## Summary
- ensure `polygraphy data to-input` creates a distinct `OrderedDict` for each padded iteration
- add a regression test that preserves separate values for multiple input iterations

## Context
This addresses the `polygraphy data to-input` aliasing bug described in #4607. The broader `debug reduce` multi-iteration limitation noted in that issue is not changed here.

## Validation
- Exercised the actual `ToInput().run_impl(...)` path with two saved input iterations and verified both are preserved
- Reproduced the old `[OrderedDict()] * n` aliasing behavior and verified the new list-comprehension behavior creates distinct dictionaries
- `PYTHONPATH=tools/Polygraphy /private/tmp/tensorrt-polygraphy-tests-py311/bin/python -m py_compile tools/Polygraphy/polygraphy/tools/data/subtool/to_input.py tools/Polygraphy/tests/tools/test_data.py`
- `git show --check --stat HEAD`

Note: I could not run the official `pytest tools/Polygraphy/tests/tools/test_data.py` suite locally because `tools/Polygraphy/tests/tools/conftest.py` imports `tensorrt` during collection. TensorRT wheels are not available for this local macOS arm64 environment (Darwin 25.3.0, no `nvidia-smi`), so collection fails before reaching the test.