### PR TITLE
Fix: Update samples README using the link to the v11.0 data

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -45,7 +45,7 @@
 
 Many samples require the TensorRT sample data package. If not already mounted under `/usr/src/tensorrt/data` (NVIDIA NGC containers), download and extract it:
 
-1. Download the sample data from [TensorRT GitHub Releases](https://github.com/NVIDIA/TensorRT/releases).
+1. Download the current [TensorRT sample data package](https://github.com/NVIDIA/TensorRT/releases/download/v11.0/tensorrt_sample_data_20260602.zip). Sample data is updated only when needed, so the package may be hosted under an earlier TensorRT release.
 
 2. Extract and set up the data:
     ```bash


### PR DESCRIPTION
## Description.

 * Having the direct link in the README makes easier for automated testing jobs to download, and install the correspoding sample data to run specific tests.

 * v11.0 sample data is used as well for v11.1 samples.