### PR TITLE
instanceNormalizationPlugin: use public __half2float instead of private __internal_half2float

### DIFF
--- a/plugin/instanceNormalizationPlugin/instanceNormalizationPlugin.cu
+++ b/plugin/instanceNormalizationPlugin/instanceNormalizationPlugin.cu
@@ -69,7 +69,9 @@ InstanceNormalizationV3Plugin::InstanceNormalizationV3Plugin(
             for (int32_t c = 0; c < input.count; ++c)
             {
                 auto const value = static_cast<unsigned short const*>(input.values);
-                output.push_back(__internal_half2float(value[c]));
+                __half_raw raw;
+                raw.x = value[c];
+                output.push_back(__half2float(raw));
             }
         }
         else

--- a/plugin/instanceNormalizationPlugin/instanceNormalizationPluginLegacy.cu
+++ b/plugin/instanceNormalizationPlugin/instanceNormalizationPluginLegacy.cu
@@ -72,7 +72,9 @@ InstanceNormalizationPlugin::InstanceNormalizationPlugin(
             for (int32_t c = 0; c < input.count; ++c)
             {
                 auto const value = static_cast<unsigned short const*>(input.values);
-                output.push_back(__internal_half2float(value[c]));
+                __half_raw raw;
+                raw.x = value[c];
+                output.push_back(__half2float(raw));
             }
         }
         else


### PR DESCRIPTION
Fixes #4810.

Both `instanceNormalizationPlugin.cu` and `instanceNormalizationPluginLegacy.cu` convert half-precision scale/bias weights to float with `__internal_half2float`, a private `static inline` helper defined inside `cuda_fp16.hpp` rather than part of the public CUDA API. It compiles under nvcc, which brings the helper into scope, but fails under other CUDA-compatible compilers (e.g. clang-CUDA) with an undeclared-identifier error, and would also block a HIP/ROCm port.

This wraps the raw bits in a `__half_raw` and calls the public `__half2float` instead, which performs the same conversion (verified against all bit patterns of interest — zero, subnormal, normal, infinities). No behavior change under nvcc, just a documented public API instead of a private header internal.