### PR TITLE
Polygraphy: rename the shadowed is_on_gpu test so is_on_cpu is actually tested

### DIFF
--- a/tools/Polygraphy/tests/util/test_array.py
+++ b/tools/Polygraphy/tests/util/test_array.py
@@ -96,7 +96,7 @@ def test_is_on_cpu(obj, is_on_cpu):
         (cuda.DeviceArray(shape=(2, 3), dtype=DataType.FLOAT32), True),
     ],
 )
-def test_is_on_cpu(obj, is_on_gpu):
+def test_is_on_gpu(obj, is_on_gpu):
     assert util.array.is_on_gpu(obj) == is_on_gpu
 
 


### PR DESCRIPTION
## Description

`tools/Polygraphy/tests/util/test_array.py` defines `test_is_on_cpu` **twice**:

```python
@pytest.mark.parametrize("obj, is_on_cpu", [... True, True, False, False])
def test_is_on_cpu(obj, is_on_cpu):
    assert util.array.is_on_cpu(obj) == is_on_cpu      # line 86

@pytest.mark.parametrize("obj, is_on_gpu", [... False, False, True, True])
def test_is_on_cpu(obj, is_on_gpu):                    # line 99  <-- same name
    assert util.array.is_on_gpu(obj) == is_on_gpu
```

The second `def` rebinds the module-level name, so the first function object is
discarded before pytest ever sees it. The result is that **`util.array.is_on_cpu`
has no test coverage at all** — the four cases that pytest does collect under the
name `test_is_on_cpu` are in fact the `is_on_gpu` cases.

From the body and the parametrize ids it is clear the second one was meant to be
`test_is_on_gpu` (it asserts `util.array.is_on_gpu`, and its expectations are the
exact inverse of the first block's).

## Reproduction

Minimal standalone reduction of the same two-`def` structure, before and after
this change:

```
$ pytest --collect-only -q test_before.py
test_before.py::test_is_on_cpu[np-False]
test_before.py::test_is_on_cpu[t_cpu-False]
test_before.py::test_is_on_cpu[t_cuda-True]
test_before.py::test_is_on_cpu[dev-True]
4 tests collected

$ pytest --collect-only -q test_after.py
test_after.py::test_is_on_cpu[np-True]
test_after.py::test_is_on_cpu[t_cpu-True]
test_after.py::test_is_on_cpu[t_cuda-False]
test_after.py::test_is_on_cpu[dev-False]
test_after.py::test_is_on_gpu[np-False]
test_after.py::test_is_on_gpu[t_cpu-False]
test_after.py::test_is_on_gpu[t_cuda-True]
test_after.py::test_is_on_gpu[dev-True]
8 tests collected
```

Note the ids in the "before" run: the surviving `test_is_on_cpu` carries the
`is_on_gpu` expectations (`np-False`), confirming the CPU test is gone.

## Fix

Rename the second definition to `test_is_on_gpu`. One line, no behavioural
change to Polygraphy itself; it restores the four `is_on_cpu` cases
(4 collected → 8 collected in this file).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
